### PR TITLE
fix: set correct base path for docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -57,7 +57,7 @@ jobs:
         doctave build --release --allow-failed-checks
 
     - name: GitHub Pages
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       uses: crazy-max/ghaction-github-pages@v2.6.0
       with:
         build_dir: site/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The API documentation can be found at http://localhost:5000/docs
 <a id="development"></a>
 ## :dizzy: Development
 
-See the [development](https://fictional-system-acdaeb8b.pages.github.io/) docs if you want to start developing.
+See the [docs](https://equinor.github.io/template-fastapi-react/) if you want to start developing.
 
 <a id="Contributing"></a>
 ## :+1: Contributing

--- a/doctave.yaml
+++ b/doctave.yaml
@@ -1,2 +1,3 @@
 ---
 title: "Template Fastapi React"
+base_path: /template-fastapi-react


### PR DESCRIPTION
## Why is this pull request needed?

* After going public we need to set base path for docs in GH pages

## What does this pull request change?

* Set base_path to  /template-fastapi-react

## Issues related to this change: