### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,7 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-# Explicitly declare text files you want to always be normalized and converted
-# to native line endings on checkout.
-
-# Declare files that will always have CRLF line endings on checkout.
+# Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
 
 # Denote all files that are truly binary and should not be modified.


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because differences in line endings for the init.sh file causes API build to fail.

## What does this pull request change?

Adds a gitattributes file that hopefully forces LF endings on bash files for all users, independently of OS.

## Issues related to this change: