### PR TITLE
fix: env_file in docker-compose.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,6 +8,8 @@ services:
     image: template-api-dev
     volumes:
       - ./api/src/:/code
+    env_file:
+      - .env
     environment:
       ENVIRONMENT: local
       LOGGING_LEVEL: debug
@@ -41,12 +43,16 @@ services:
     stdin_open: true
     volumes:
       - ./web/src:/code/src
+    env_file:
+      - .env
     environment:
       - NODE_ENV=development
 
   db:
     volumes:
       - ./data/db:/data/db
+    env_file:
+      - .env
     environment:
       MONGO_INITDB_ROOT_USERNAME: $MONGODB_USERNAME
       MONGO_INITDB_ROOT_PASSWORD: $MONGODB_PASSWORD
@@ -56,6 +62,8 @@ services:
     restart: unless-stopped
     ports:
       - "8081:8081"
+    env_file:
+      - .env
     environment:
       ME_CONFIG_MONGODB_SERVER: db
       ME_CONFIG_MONGODB_ADMINUSERNAME: $MONGODB_USERNAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     links:
       - web
       - api
+    env_file:
+      - .env
 
   api:
     build: ./api
@@ -17,13 +19,19 @@ services:
     restart: unless-stopped
     depends_on:
       - db
+    env_file:
+      - .env
 
   web:
     build: ./web
     image: ghcr.io/equinor/template-fastapi-react/web
     restart: unless-stopped
+    env_file:
+      - .env
 
   db:
     image: mongo:5.0.9
     restart: unless-stopped
     command: --auth --quiet
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     links:
       - web
       - api
-    env_file:
-      - .env
 
   api:
     build: ./api
@@ -19,19 +17,13 @@ services:
     restart: unless-stopped
     depends_on:
       - db
-    env_file:
-      - .env
 
   web:
     build: ./web
     image: ghcr.io/equinor/template-fastapi-react/web
     restart: unless-stopped
-    env_file:
-      - .env
 
   db:
     image: mongo:5.0.9
     restart: unless-stopped
     command: --auth --quiet
-    env_file:
-      - .env


### PR DESCRIPTION
_Adding env_file-property to service-declarations in `docker-compose.yml` stops `docker-compose up` from running without a `.env`-file present._

## Why is this pull request needed?

This pull request is needed because of a bug happening if there is no `.env`-file present when `docker-compose up` is run the first time. If so, the `data/`-folder will contain incompatible data, meaning it will have to be deleted before another attempt is made. 
As there are no/few cases where _no_ environment variables are in use, a simple fix is to require it in `docker-compose.yml`.

## What does this pull request change?

Adds the bottom two lines to each service declaration in ~`docker-compose.yml`~.
EDIT: Changes moved to `docker-compose.override.yml`.  
```yml
services:
  my-app:
    env_file:
      - .env
```

## Issues related to this change:
None.