### PR TITLE
docs: turn puml diagrams sideways

### DIFF
--- a/documentation/docs/contributing/development-guide/coding/01-architecture.md
+++ b/documentation/docs/contributing/development-guide/coding/01-architecture.md
@@ -14,6 +14,7 @@ The Context diagram is a good starting point for diagramming and documenting a s
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
+left to right direction
 LAYOUT_WITH_LEGEND()
 
 Person(application_users, "Application User", "A user of the todo application.")
@@ -34,6 +35,7 @@ Once you understand how your system interacts with users and external systems, a
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
+left to right direction
 LAYOUT_WITH_LEGEND()
 
 Person(application_users, "Application User", "A user of the todo application.")
@@ -61,6 +63,7 @@ The Component diagram shows how a container is made up of a number of components
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
+left to right direction
 LAYOUT_WITH_LEGEND()
 
 Person(application_users, "Application User", "A user of the todo application.")


### PR DESCRIPTION
## What's new?
The plantUML diagrams are now horizontal, not vertical. That saves us a lot of real-estate on the screen when viewing. 

I got this approved by @hakoneriksson, although @eoaksnes and @paultrygs claimed it was a war-crime to show C4-diagrams horizontally. 

### Before
![image](https://user-images.githubusercontent.com/37065184/196440303-809485c1-f64b-4977-9387-598b05f0bf3e.png)
(I had to zoom out in my browser to see it all)

### Now
![image](https://user-images.githubusercontent.com/37065184/196440151-ec423ccd-c5b6-4b87-8f4f-4f09f7662c26.png)



## Issues related to this change:
None. 