### PR TITLE
docs: revert left to right for diagrams

### DIFF
--- a/documentation/docs/contribute/development-guide/coding/01-architecture.md
+++ b/documentation/docs/contribute/development-guide/coding/01-architecture.md
@@ -14,7 +14,6 @@ The Context diagram is a good starting point for diagramming and documenting a s
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
-left to right direction
 LAYOUT_WITH_LEGEND()
 
 Person(application_users, "Application User", "A user of the todo application.")
@@ -35,7 +34,6 @@ Once you understand how your system interacts with users and external systems, a
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
-left to right direction
 LAYOUT_WITH_LEGEND()
 
 Person(application_users, "Application User", "A user of the todo application.")
@@ -63,7 +61,6 @@ The Component diagram shows how a container is made up of a number of components
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
 !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
-left to right direction
 LAYOUT_WITH_LEGEND()
 
 Person(application_users, "Application User", "A user of the todo application.")


### PR DESCRIPTION
## Why is this pull request needed?

* The diagrams generated are too small to see for an old person (like me)

## What does this pull request change?

* Remove `left to right direction` option

## Issues related to this change: