### PR TITLE
docs: use tabs to show platform specific options

### DIFF
--- a/documentation/docs/contribute/development-guide/01-setup.md
+++ b/documentation/docs/contribute/development-guide/01-setup.md
@@ -1,5 +1,10 @@
 # Setup
 
+```mdx-code-block
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+```
+
 ## Prerequisites
 
 To work with the template monorepo you'll need to install [these tools](../../about/running/01-prerequisites.md).
@@ -42,31 +47,31 @@ From inside the /api folder.
 
 ### Create virtualenv
 
+Virtual environment is used for running unit tests with pre-commit and upgrade packages. It also can be used to run the application if you not are using Docker.
+
 ```shell
 python3 -m venv .venv
 ```
 
-Virtual environment is used for running unit tests with pre-commit and upgrade packages. It also can be used to run the application if you not are using Docker.
-
 ### Activate virtualenv
 
-<details>
-<summary>Linux</summary>
+<Tabs groupId="operating-system">
+<TabItem value="linux" label="Linux">
 
-```shell
-$ source .venv/bin/activate
-```
-</details>
-
-<details>
-<summary>Windows</summary>
-
-```shell
-$ .\venv\Scripts\Activate.ps1
-$ pip install --upgrade pip
+```bash
+source .venv/bin/activate
 ```
 
-</details>
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```powershell
+.\venv\Scripts\Activate.ps1
+pip install --upgrade pip
+```
+
+</TabItem>
+</Tabs>
 
 ### Install Poetry
 

--- a/documentation/docs/contribute/development-guide/03-testing.md
+++ b/documentation/docs/contribute/development-guide/03-testing.md
@@ -2,23 +2,35 @@
 
 ## API
 
+```mdx-code-block
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+```
+
 The application has two types of API tests: unit tests and integration tests.
 
 ### Unit tests
 
 You will find unit tests under `src/tests/unit`.
 
-Using docker:
+<Tabs groupId="api-testing">
+<TabItem value="using-docker" label="Using docker">
 
 ```shell
 docker-compose run --rm api pytest
 ```
 
-Without using docker:
+</TabItem>
+<TabItem value="without-using-docker" label="Without using docker">
 
 ```shell
+cd api/
 pytest
 ```
+
+</TabItem>
+</Tabs>
+
 
 As a general rule, unit tests should not have any external dependencies - especially on the file system.
 
@@ -34,15 +46,20 @@ These tests depends on mongodb and that it's running.
 
 ### Unit tests
 
-Without using docker:
+<Tabs groupId="web-testing">
+<TabItem value="using-docker" label="Using docker">
 
 ```shell
 docker-compose run --rm web yarn test
 ```
 
-Not using docker:
+</TabItem>
+<TabItem value="without-using-docker" label="Without using docker">
 
 ```shell
 cd web/
 yarn test
 ```
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
## Why is this pull request needed?

* Use tabs to show different options in nice way

## What does this pull request change?

* Replace details/summary with tabs

## Issues related to this change:

<img width="740" alt="image" src="https://user-images.githubusercontent.com/1190419/199515830-549239f7-5439-4b4d-a51b-b917a92ee6d7.png">

