### PR TITLE
docs: add link to API docs

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -77,6 +77,11 @@ async function createConfig() {
             },
             { to: '/docs/changelog', label: 'Changelog', position: 'left' },
             {
+              href: 'https://template-fastapi-react.app.radix.equinor.com/api/docs',
+              label: 'API',
+              position: 'right',
+            },
+            {
               href: 'https://github.com/equinor/template-fastapi-react',
               label: 'GitHub',
               position: 'right',


### PR DESCRIPTION
## Why is this pull request needed?

* Add link to open API docs 

## What does this pull request change?

* Adding link to header

## Issues related to this change: