### PR TITLE
docs: add link to demo

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -77,6 +77,11 @@ async function createConfig() {
             },
             { to: '/docs/changelog', label: 'Changelog', position: 'left' },
             {
+              href: 'https://template-fastapi-react.app.radix.equinor.com',
+              label: 'Demo',
+              position: 'right',
+            },
+            {
               href: 'https://template-fastapi-react.app.radix.equinor.com/api/docs',
               label: 'API',
               position: 'right',


### PR DESCRIPTION
## Why is this pull request needed?

* Add link to easy open the demo

## What does this pull request change?

* Add link to demo in top menu

## Issues related to this change: