### PR TITLE
docs: remove calculations from description

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -20,7 +20,7 @@ description_md = """
 ### Description
 A RESTful API for handling todo items.
 
-Anyone in Equinor are authorized to run these calculations.
+Anyone in Equinor are authorized to use the API.
  * Click **Authorize** to login and start testing.
 
 ### Resources


### PR DESCRIPTION
## Why is this pull request needed?

* Remove calculations from description of API

## What does this pull request change?

* Replace calc text

## Issues related to this change: