### PR TITLE
chore: substitute HashRouter with BrowserRouter in web app

### DIFF
--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,8 +1,8 @@
-import { createHashRouter } from 'react-router-dom'
+import { createBrowserRouter } from 'react-router-dom'
 import { TodoListPage } from './pages/TodoListPage'
 import InvalidUrl from './common/components/InvalidUrl'
 
-export const router = createHashRouter([
+export const router = createBrowserRouter([
   {
     path: '/',
     element: <TodoListPage />,


### PR DESCRIPTION
## Why is this pull request needed?
BrowserRouter is recommended for a web projects [(https://reactrouter.com/en/main/routers/picking-a-router)](https://reactrouter.com/en/main/routers/picking-a-router#web-projects)

Now the web app follows the recommend setup from the react-router docs: https://reactrouter.com/en/main/routers/create-browser-router


## What does this pull request change?
Substitute HashRouter with BrowserRouter
## Issues related to this change:
closes #45 