### PR TITLE
fix: make useTodos simpler to use

### DIFF
--- a/web/src/features/todos/todo-list/TodoList.tsx
+++ b/web/src/features/todos/todo-list/TodoList.tsx
@@ -34,7 +34,8 @@ const AddItem = (props: { onAddItem: (id: string) => void }) => {
 }
 
 const TodoList = () => {
-  const [todos, isLoading, addItem, removeItem, toggleItem, error] = useTodos()
+  const { todos, isLoading, addItem, removeItem, toggleItem, error } =
+    useTodos()
 
   if (isLoading) return <CircularProgress />
 

--- a/web/src/hooks/useTodos.tsx
+++ b/web/src/hooks/useTodos.tsx
@@ -4,14 +4,14 @@ import TodoAPI from '../api/TodoAPI'
 import { AxiosError } from 'axios'
 import { AddTodoResponse, ErrorResponse } from '../api/generated'
 
-const useTodos = (): [
-  AddTodoResponse[],
-  boolean,
-  (title: string) => void,
-  (id: string) => void,
-  (id: string) => void,
-  AxiosError | null
-] => {
+const useTodos = (): {
+  todos: AddTodoResponse[]
+  isLoading: boolean
+  addItem: (title: string) => void
+  removeItem: (id: string) => void
+  toggleItem: (id: string) => void
+  error: AxiosError | null
+} => {
   const [todos, setTodos] = useState<AddTodoResponse[]>([])
   const [isLoading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<AxiosError | null>(null)
@@ -83,7 +83,7 @@ const useTodos = (): [
       .finally(() => setLoading(false))
   }
 
-  return [todos, isLoading, addItem, removeItem, toggleItem, error]
+  return { todos, isLoading, addItem, removeItem, toggleItem, error }
 }
 
 export default useTodos


### PR DESCRIPTION
## Why is this pull request needed?
Make useTodos simpler to use. Now, the user don't have to remember the order of things returned from useTodos

## What does this pull request change?
make useTodos simpler to use

## Issues related to this change:
none