### PR TITLE
test(docs): Add testing of docs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     secrets:
       CR_SECRET:
-        description: 'Secret to authenticate if using an other container registry than Github'
+        description: "Secret to authenticate if using an other container registry than Github"
         required: false
 
 env:
@@ -24,7 +24,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install pre-commit
         run: pip install pre-commit
@@ -51,7 +51,7 @@ jobs:
           docker build --target development --tag api-development ./api # TODO: --cache-from $API_IMAGE
 
       - name: BDD Integration tests
-        if: ${{ false }}  # disable for now
+        if: ${{ false }} # disable for now
         run: docker-compose -f docker-compose.yml -f docker-compose.ci.yml run api behave
 
       - name: Pytest Integration tests
@@ -67,3 +67,34 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull $WEB_IMAGE
           docker build --cache-from $WEB_IMAGE --target development --tag web-dev ./web
+
+  test-docs:
+    name: test-docs
+    runs-on: ubuntu-latest
+
+    steps:
+      # If you know your docs does not rely on anything outside of the documentation folder, the commented out code below can be used to only test the docs build if the documentation folder changes.
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@main
+        # with:
+        #   fetch-depth: 0
+
+      # - name: "Get number of changed documentation files"
+      #   id: docs-changes
+      #   shell: bash
+      #   run: echo "::set-output name=changes::$(git diff --name-only $(git merge-base HEAD origin/main) HEAD | grep documentation/ | wc -l)"
+
+      - name: "Setup node"
+        # if: steps.docs-changes.outputs.changes > 0
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: documentation/yarn.lock
+
+      - name: Install dependencies and build website
+        # if: steps.docs-changes.outputs.changes > 0
+        run: |
+          cd documentation
+          yarn install --frozen-lockfile
+          yarn build


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed to ensure our changes does not break the docs build

## What does this pull request change?

Creates a new test. It will check out the repo and build the docs.
In the template, there are several cases there the documentation displays parts of code from outside of the documentation folder, and if that code is not found the build will fail. If the template had not done that, we could have run a check to see if anything in the docs folder had changed and only run the time consuming build if it had. I've therefore left such a functionality in the comments, in case it might become useful for other repos using this template.

## Issues related to this change: