### PR TITLE
fix (cicd): use correct branch name (`master` => `main`)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '34 19 * * 0'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ env:
   NGINX_IMAGE: ghcr.io/equinor/template-fastapi-react/nginx
 
 jobs:
-  build-and-publish-web-master:
+  build-and-publish-web-main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -50,7 +50,7 @@ jobs:
           docker tag $WEB_IMAGE $WEB_IMAGE:${{ inputs.image-tag }}
           docker push $WEB_IMAGE:${{ inputs.image-tag }}
 
-  build-and-publish-api-master:
+  build-and-publish-api-main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
## Why is this pull request needed?

To fix incorrect references to the `master` branch

## What does this pull request change?

Updates refs to `master` => `main`

## Issues related to this change: