### PR TITLE
docs: add configuration section to  "extending the API" page

### DIFF
--- a/documentation/docs/contribute/development-guide/coding/extending-the-api/index.md
+++ b/documentation/docs/contribute/development-guide/coding/extending-the-api/index.md
@@ -50,3 +50,16 @@ The API has a feature-based folder structure following the principles of [Clean 
 Entities and data providers can be shared between features (the entrypoints and use-cases).
 
 :::
+
+# Configuration
+
+All configuration parameters are expected to be environment variables, and are defined in this file `api/src/config.py`.
+
+```mdx-code-block
+import CodeBlock from '@theme/CodeBlock';
+import auth from '!!raw-loader!@site/../api/src/config.py';
+
+<CodeBlock language="jsx">{auth}</CodeBlock>
+```
+
+See [configuration](../../../../about/running/configure) for a description of the different configuration options available.

--- a/documentation/docs/contribute/development-guide/coding/extending-the-web/index.md
+++ b/documentation/docs/contribute/development-guide/coding/extending-the-web/index.md
@@ -66,9 +66,11 @@ External dependencies:
 * The app is using [react-oauth2-code-pkce](https://www.npmjs.com/package/react-oauth2-code-pkce) for Oauth2 authentication. 
 * The app is using [react-router-dom](https://www.npmjs.com/package/react-router-dom) for routing. 
 
-# Configuration
+## Configuration
 
-## Oauth2
+See [configuration](../../../../about/running/configure) for a description of the different configuration options available.
+
+### Oauth2
 
 The AuthProvider are using the configuration defined in `web/src/auth`. 
 
@@ -79,7 +81,7 @@ import auth from '!!raw-loader!@site/../web/src/auth';
 <CodeBlock language="jsx">{auth}</CodeBlock>
 ```
 
-## Routes
+### Routes
 
 The RouterProvider are using the router defined in `web/src/router`.
 


### PR DESCRIPTION
## Why is this pull request needed?

* Add configuration section to how to extend the API

## What does this pull request change?

* Add text about configuration section for API

## Issues related to this change: