### PR TITLE
build: fix mac m1 virtiofs docker problem

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,12 +52,15 @@ services:
 
   db:
     volumes:
-      - ./data/db:/data/db
+      - database:/data/db
     env_file:
       - .env
     environment:
       MONGO_INITDB_ROOT_USERNAME: $MONGODB_USERNAME
       MONGO_INITDB_ROOT_PASSWORD: $MONGODB_PASSWORD
+
+volumes:
+  database:
 
   # db-ui:
   #   image: mongo-express:0.49


### PR DESCRIPTION
## Why is this pull request needed?
We have a bug on some computers, which causes the mongodb to not come online when running `docker compose up --build` _after_ initial setup. 

I know for a fact that this affects M1 macs using docker with VirtioFS enabled. I need to enable VirtioFS because it increases filesystem performance drastically in docker.

## What does this pull request change?
It adds a docker volume called `database`, and rather than mounting the `db`-container's `/data/db` to a local folder, we just mount it to the volume.

Note: This means you won't be able to read the db storage files in you local filesystem.

## Issues related to this change:
None