### PR TITLE
Feat/visualize-loading-state-better

### DIFF
--- a/web/src/features/todos/todo-list/TodoList.styled.tsx
+++ b/web/src/features/todos/todo-list/TodoList.styled.tsx
@@ -3,6 +3,16 @@ import styled from 'styled-components'
 export const StyledTodoList = styled.div`
   width: 400px;
   padding: 30px;
+  position: relative;
+`
+
+export const SpinnerContainer = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.4);
 `
 
 export const StyledInput = styled.div`

--- a/web/src/features/todos/todo-list/TodoList.tsx
+++ b/web/src/features/todos/todo-list/TodoList.tsx
@@ -1,9 +1,13 @@
 import useTodos from '../../../hooks/useTodos'
 import { FormEventHandler, useState } from 'react'
-import { Button, CircularProgress, Input } from '@equinor/eds-core-react'
+import { Button, Input, Progress } from '@equinor/eds-core-react'
 import TodoItem from './TodoItem'
 import { AddTodoResponse } from '../../../api/generated'
-import { StyledTodoList, StyledInput } from './TodoList.styled'
+import {
+  StyledTodoList,
+  StyledInput,
+  SpinnerContainer,
+} from './TodoList.styled'
 
 const AddItem = (props: { onAddItem: (id: string) => void }) => {
   const { onAddItem } = props
@@ -37,8 +41,6 @@ const TodoList = () => {
   const { todos, isLoading, addItem, removeItem, toggleItem, error } =
     useTodos()
 
-  if (isLoading) return <CircularProgress />
-
   if (error)
     return <div>{error?.response?.data.message ?? 'Something went wrong!'}</div>
 
@@ -53,6 +55,11 @@ const TodoList = () => {
           todo={todo}
         />
       ))}
+      {isLoading && (
+        <SpinnerContainer>
+          <Progress.Circular />
+        </SpinnerContainer>
+      )}
     </StyledTodoList>
   )
 }

--- a/web/src/features/todos/todo-list/TodoList.tsx
+++ b/web/src/features/todos/todo-list/TodoList.tsx
@@ -1,5 +1,5 @@
 import useTodos from '../../../hooks/useTodos'
-import { useState } from 'react'
+import { FormEventHandler, useState } from 'react'
 import { Button, CircularProgress, Input } from '@equinor/eds-core-react'
 import TodoItem from './TodoItem'
 import { AddTodoResponse } from '../../../api/generated'
@@ -9,7 +9,7 @@ const AddItem = (props: { onAddItem: (id: string) => void }) => {
   const { onAddItem } = props
   const [value, setValue] = useState('')
 
-  const handleAddItem = (event: Event) => {
+  const handleAddItem: FormEventHandler = (event) => {
     event.preventDefault()
     if (!value) return
     onAddItem(value)

--- a/web/src/hooks/useTodos.tsx
+++ b/web/src/hooks/useTodos.tsx
@@ -10,11 +10,11 @@ const useTodos = (): {
   addItem: (title: string) => void
   removeItem: (id: string) => void
   toggleItem: (id: string) => void
-  error: AxiosError | null
+  error: AxiosError<ErrorResponse> | null
 } => {
   const [todos, setTodos] = useState<AddTodoResponse[]>([])
   const [isLoading, setLoading] = useState<boolean>(true)
-  const [error, setError] = useState<AxiosError | null>(null)
+  const [error, setError] = useState<AxiosError<ErrorResponse> | null>(null)
   const { token } = useContext(AuthContext)
   const todoAPI = new TodoAPI(token)
 
@@ -23,7 +23,7 @@ const useTodos = (): {
     todoAPI
       .getAll()
       .then((response) => setTodos(response.data))
-      .catch((error: AxiosError) => setError(error))
+      .catch((error: AxiosError<ErrorResponse>) => setError(error))
       .finally(() => setLoading(false))
   }, [])
 
@@ -55,7 +55,7 @@ const useTodos = (): {
         )
         setTodos(tmpTodos)
       })
-      .catch((error: AxiosError) => setError(error))
+      .catch((error: AxiosError<ErrorResponse>) => setError(error))
       .finally(() => setLoading(false))
   }
 
@@ -79,7 +79,7 @@ const useTodos = (): {
         items[index] = todoItem
         setTodos([...items])
       })
-      .catch((error: AxiosError) => setError(error))
+      .catch((error: AxiosError<ErrorResponse>) => setError(error))
       .finally(() => setLoading(false))
   }
 


### PR DESCRIPTION
## Why is this pull request needed?
While the old loading animation worked, it wasn't smooth (it hid the ui for a fraction of a second for every action).

## What does this pull request change?
This PR makes the loading-spinner appear above the UI with a faded background. This This makes it less jittery/janky.

TODO: Upload video here.

## Issues related to this change:
None.