### PR TITLE
feat(web): clear input on add-todo

### DIFF
--- a/web/src/features/todos/todo-list/TodoList.tsx
+++ b/web/src/features/todos/todo-list/TodoList.tsx
@@ -11,8 +11,8 @@ const AddItem = (props: { onAddItem: (id: string) => void }) => {
 
   const handleAddItem = (event: Event) => {
     event.preventDefault()
-    if (!value) return
-    onAddItem(value)
+    if (value) onAddItem(value)
+    setValue('')
   }
 
   return (


### PR DESCRIPTION
## Why is this pull request needed?
It's natural that hitting `enter` when writing a todo should clear the input field. It didn't before.

## What does this pull request change?
It's natural that hitting `enter` when writing a todo should clear the input field. Now it does.

## Issues related to this change:
None.