### PR TITLE
chore(dev): make CRA use port 80 for websocket

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "WDS_SOCKET_PORT=80 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## What and why?
React hot reloading didn't work with docker-compose. Setting `WDS_SOCKET_PORT=80` allows react to hot-reload properly when using docker, because the port is exposed.

## Issues related to this change:
None.