### PR TITLE
fix(web): adding todo item now clears input

### DIFF
--- a/web/src/features/todos/todo-list/TodoList.tsx
+++ b/web/src/features/todos/todo-list/TodoList.tsx
@@ -24,6 +24,7 @@ const AddItem = (props: { onAddItem: (id: string) => void }) => {
       <form onSubmit={handleAddItem}>
         <StyledInput>
           <Input
+            value={value}
             className="input"
             placeholder="Add Task"
             onChange={(e) => setValue(e.target.value)}


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because I forgot to add this one line in yesterday's related PR #125.

## What does this pull request change?

Adds a `value={value}` line. 

## Issues related to this change:
Only that @eoaksnes notified me. No formal issue.