### PR TITLE
chore: add script to run eslint

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "yarn eslint --fix --ext .ts,.tsx ."
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Why is this pull request needed?

Some of the eslint rules are configured to give warnings, but won't cause pre-commit check to fail. Checking for warnings can be useful during development, and it's easier to do so by running `yarn lint` now that the script is added.