### PR TITLE
build: bump python version to 3.11

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 as base
+FROM python:3.11-slim as base
 WORKDIR /code
 CMD ["/code/src/init.sh", "api"]
 EXPOSE 5000

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -7,7 +7,7 @@ license = ""
 
 [tool.poetry.dependencies]
 cachetools = "^4.2.2"
-python = "3.10.*"
+python = "^3.10"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 fastapi = "^0.78.0"
 uvicorn = {extras = ["standard"], version = "^0.17.6"}


### PR DESCRIPTION
## Why is this pull request needed?

New python version released

## What does this pull request change?

Add support for python 3.11, changed docker image to slim-version (recommended by Snyk: https://snyk.io/blog/best-practices-containerizing-python-docker/)
