### PR TITLE
refactor: remove pyproject.toml parsing with extra-files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
           package-name: release-please-action
           extra-files: |
             api/pyproject.toml
+            api/src/app.py
     outputs:
        release_created: ${{ steps.release.outputs.release_created }}
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -17,7 +17,6 @@ cryptography = "37.0.2"  # Locked because of a bad 37.0.3 release. (https://cryp
 # Not a direct dependecy, but needed to get certificates
 certifi = "^2022.6.15"
 requests = "^2.27.1"
-toml = "^0.10.2"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.19.0"

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -1,14 +1,10 @@
-from pathlib import Path
-
 import click
-import toml
 from fastapi import APIRouter, FastAPI, Security
 from fastapi.exceptions import RequestValidationError
 from starlette.middleware import Middleware
 
 from authentication.authentication import auth_with_jwt
 from common.exception_handlers import validation_exception_handler
-from common.logger import logger
 from common.middleware import TimerHeaderMiddleware
 from common.responses import responses
 from config import config
@@ -31,17 +27,6 @@ Anyone in Equinor are authorized to use the API.
 """
 
 
-def get_api_version_from_pyproject(pyproject_path: Path) -> str:
-    try:
-        pyproject_text = pyproject_path.read_text()
-        pyproject_data = toml.loads(pyproject_text)
-        metadata = pyproject_data["tool"]["poetry"]
-        return str(metadata["version"])
-    except FileNotFoundError:
-        logger.error("pyproject.toml not found, setting api version to 0.0.0")
-        return "0.0.0"
-
-
 def create_app() -> FastAPI:
     public_routes = APIRouter()
     public_routes.include_router(health_check_feature.router)
@@ -57,7 +42,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         root_path="/api",
         title="Template FastAPI React",
-        version=get_api_version_from_pyproject(Path("../pyproject.toml")),
+        version="1.2.1",  # x-release-please-version
         description=description_md,
         responses=responses,
         middleware=middleware,


### PR DESCRIPTION
## Why is this pull request needed?

The flow of updating api-version in openAPI spec was unecessary complicated

## What does this pull request change?

- Api version (in openAPI spec) is now set directly by release-please
- remove toml as extra dependency

## Issues related to this change: