### PR TITLE
refactor: use <Icon> data prop instead of name

### DIFF
--- a/web/src/common/components/Header.tsx
+++ b/web/src/common/components/Header.tsx
@@ -3,8 +3,6 @@ import { AuthContext } from 'react-oauth2-code-pkce'
 import { Button, Icon, TopBar, Typography } from '@equinor/eds-core-react'
 import { log_out, receipt } from '@equinor/eds-icons'
 
-Icon.add({ receipt })
-
 const Header = () => {
   const { tokenData, logOut } = useContext(AuthContext)
 
@@ -14,7 +12,7 @@ const Header = () => {
   return (
     <TopBar>
       <TopBar.Header>
-        <Icon name="receipt" />
+        <Icon data={receipt} />
         Todo App
       </TopBar.Header>
       <TopBar.Actions style={{ gap: 8 }}>

--- a/web/src/features/todos/todo-list/TodoItem.tsx
+++ b/web/src/features/todos/todo-list/TodoItem.tsx
@@ -9,8 +9,6 @@ import {
 import { undo, done, remove_outlined } from '@equinor/eds-icons'
 import { AddTodoResponse } from '../../../api/generated'
 
-Icon.add({ undo, done, remove_outlined })
-
 const TodoItem = (props: {
   todo: AddTodoResponse
   onToggle: (id: string) => void
@@ -35,7 +33,7 @@ const TodoItem = (props: {
         <Tooltip title={`Mark as ${todo.is_completed ? 'incomplete' : 'done'}`}>
           <Button variant="ghost_icon" onClick={() => onToggle(todo.id)}>
             <Icon
-              name={todo.is_completed ? 'undo' : 'done'}
+              data={todo.is_completed ? undo : done}
               size={24}
               title={todo.is_completed ? 'incomplete' : 'done'}
             />
@@ -43,7 +41,7 @@ const TodoItem = (props: {
         </Tooltip>
         <Tooltip title="Remove">
           <Button variant="ghost_icon" onClick={() => onRemove(todo.id)}>
-            <Icon name="remove_outlined" size={24} title="Remove" />
+            <Icon data={remove_outlined} size={24} title="Remove" />
           </Button>
         </Tooltip>
       </Card.Header>


### PR DESCRIPTION
## Why is this pull request needed?
EDS allows [two methods to using their icons](https://eds-storybook-react.azurewebsites.net/?path=/docs/icons-icon--introduction#usage):
1. First add the icons to the "loaded set" (make sure to only do this once!) and use the `name=""` prop to use it (no typechecking or autocomplete here).
2. Just import the icon and use the `data={}` prop.

The second method is simpler. Why not use it?

## What does this pull request change?
Replaces usage of `name=""` prop with `data={}` prop.

--- 

Note: I'm not sure how this affects e.g. loading times. EDS provides no information on potential differences between the two methods, and from their presentation they are equal. 

As far as I understand, the icons are loaded into the javascript bundle in both cases, and therefore I can't imagine there should be any difference in performance.

Feel free to comment on this if you believe the performance of this solution is poorer than the former solution.

## Issues related to this change:
None.