### PR TITLE
build(ci/cd): update flake8 repo location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
         types: [file]
         args: ["--config=web/.eslintrc.json", "--ignore-path=web/.eslintignore"]
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
## Why and what?
Flake switched from gitlab to github today - so we need to do this. This PR fixes pipeline issues on other PRs (like #146). 


## Issues related to this change:
None.