### PR TITLE
Fix: replace deprecated output definition

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -60,4 +60,4 @@ jobs:
       - name: Retrieve new version
         id: tag
         run: |
-          echo "::set-output name=version::$(git describe HEAD)"
+          echo "version=$(git describe HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,7 +82,7 @@ jobs:
       # - name: "Get number of changed documentation files"
       #   id: docs-changes
       #   shell: bash
-      #   run: echo "::set-output name=changes::$(git diff --name-only $(git merge-base HEAD origin/main) HEAD | grep documentation/ | wc -l)"
+      #   run: echo "changes=$(git diff --name-only $(git merge-base HEAD origin/main) HEAD | grep documentation/ | wc -l)" >> $GITHUB_OUTPUT
 
       - name: "Setup node"
         # if: steps.docs-changes.outputs.changes > 0


### PR DESCRIPTION
## What does this pull request change?
The `set-output` command in the GitHub Actions workflows, [is about to become deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## Why is this pull request needed?
To change from the 
```sh
echo "::set-output name=tag-ref::TAG_REF"
```
to the new
```sh
echo "tag-ref=$TAG_REF" >> $GITHUB_OUTPUT
```
stanza

## Issues related to this change

