### PR TITLE
ci: Include all commit types in changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,9 @@ jobs:
           extra-files: |
             api/pyproject.toml
             api/src/app.py
+          changelog-types: '[{ "type": "feat", "section": "Features", "hidden": false },{ "type": "feature", "section": "Features", "hidden": false },{ "type": "fix", "section": "Bug Fixes", "hidden": false },{ "type": "perf", "section": "Performance Improvements", "hidden": false },{ "type": "revert", "section": "Reverts", "hidden": false },{ "type": "docs", "section": "Documentation", "hidden": false },{ "type": "style", "section": "Styles", "hidden": false },{ "type": "chore", "section": "Miscellaneous Chores", "hidden": false },{ "type": "refactor", "section": "Code Refactoring", "hidden": false },{ "type": "test", "section": "Tests", "hidden": false },{ "type": "build", "section": "Build System", "hidden": false },{ "type": "ci", "section": "Continuous Integration", "hidden": false }]'
     outputs:
-       release_created: ${{ steps.release.outputs.release_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
 
   deploy-prod:
     needs: release-please

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         always_run: true
 
   - repo: https://github.com/ambv/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         language_version: python3.10
@@ -47,14 +47,14 @@ repos:
         files: ^api/.*\.py$
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.2
+    rev: v2.1.3
     hooks:
       - id: pycln
         args: [./api/src, --config=api/pyproject.toml]
         pass_filenames: false
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -68,9 +68,8 @@ repos:
         args:
           ["--config=web/.prettierrc.js", "--ignore-path=web/.prettierignore"]
 
-
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v8.31.0'
+    rev: "v8.33.0"
     hooks:
       - id: eslint
         additional_dependencies:
@@ -84,7 +83,7 @@ repos:
           - eslint-plugin-prettier # runs prettier as an eslint rule
           - eslint-plugin-react # react specific linting rules
           - eslint-plugin-react-hooks # enforces the rules of hooks
-        files: ^web/src/.*\.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
+        files: ^web/src/.*\.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
         types: [file]
         args: ["--config=web/.eslintrc.json", "--ignore-path=web/.eslintignore"]
 
@@ -93,9 +92,15 @@ repos:
     hooks:
       - id: flake8
         files: ^api/src/.*\.py$
-        args: [ '--max-line-length=119', '--max-complexity=18', '--select=B,C,E,F,W,T4,B9', '--ignore=E203,E266,E501,W503' ]
+        args:
+          [
+            "--max-line-length=119",
+            "--max-complexity=18",
+            "--select=B,C,E,F,W,T4,B9",
+            "--ignore=E203,E266,E501,W503",
+          ]
 
-# The path to the venv python interpreter differ between linux and windows. An if/else is used to find it on either.
+  # The path to the venv python interpreter differ between linux and windows. An if/else is used to find it on either.
   - repo: local
     hooks:
       - id: mypy


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because release-please, as default, only updates/creates a release PR if the commit is of type feat or fix. That can be problematic for low-intensity projects that mostly just updates packages.

## What does this pull request change?

The PR adds a json string that would pick up all the common commit types. The point is to demonstrate how this can be done and provide a reasonable default.

## Issues related to this change: