### PR TITLE
ci: Fix bug in publish docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,6 +18,9 @@ on:
         required: false
         type: string
 
+env:
+  GITHUB_PAGES_BRANCH: gh-pages
+
 jobs:
   publish-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because publish docs workflow fails

## What does this pull request change?

Adds github_pages_branch as env variable

## Issues related to this change: