### PR TITLE
Fix dead link in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Want to contribute to the template? There are a few things you need to know.
 
-We wrote a [contribution guide](https://equinor.github.io/template-fastapi-react/docs/category/contribute) to help you get started.
+We wrote a [contribution guide](https://equinor.github.io/template-fastapi-react/docs/contribute/how-to-start-contributing) to help you get started.


### PR DESCRIPTION
## Why is this pull request needed?
To lower the threshold for contributions.
Previous link 404's.

## What does this pull request change?
Change link to contributing page in `CONTRIBUTING.md` to correct page.

## Issues related to this change:
None