### PR TITLE
Ci/move to radix playground

### DIFF
--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       image-tag: latest
-      oauth-redirect-url: 'https://proxy-template-fastapi-react-test.radix.equinor.com/'
+      oauth-redirect-url: 'https://proxy-template-fastapi-react-test.playground.radix.equinor.com/'
 
   deploy-test:
     needs: publish-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ on:
         type: string
       oauth-redirect-url:
         description: "Redirect url for oauth. Should be the public url to access the web app"
-        default: "https://template-fastapi-react.app.radix.equinor.com"
+        default: "https://template-fastapi-react.app.playground.radix.equinor.com"
         required: true
         type: string
     secrets:

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       image-tag: production
-      oauth-redirect-url: 'https://template-fastapi-react.app.radix.equinor.com'
+      oauth-redirect-url: 'https://template-fastapi-react.app.playground.radix.equinor.com'
 
   deploy-prod:
     needs: publish-production

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a **solution template** for creating a Single Page App (SPA) with React 
 [Development](#development) •
 [Contributing](#contributing)
 
-A demo is running at https://template-fastapi-react.app.radix.equinor.com
+A demo is running at https://template-fastapi-react.app.playground.radix.equinor.com
 
 </div>
 

--- a/documentation/docs/about/01-introduction.md
+++ b/documentation/docs/about/01-introduction.md
@@ -4,4 +4,4 @@
 
 This is a solution template for creating a Single Page App (SPA) with React and FastAPI following the principles of Clean Architecture.
 
-The template provides an example implementation of a [todo application](https://template-fastapi-react.app.radix.equinor.com/). The todo app implementation is fairly basic. A user can add a task, mark a task as completed and delete an added task. The purpose of the minimalist todo app implementation is to learn and practice what the concepts of [clean architecture](../contribute/development-guide/coding/01-architecture.md) are, and how they can be used in a REST API. 
+The template provides an example implementation of a [todo application](https://template-fastapi-react.app.playground.radix.equinor.com/). The todo app implementation is fairly basic. A user can add a task, mark a task as completed and delete an added task. The purpose of the minimalist todo app implementation is to learn and practice what the concepts of [clean architecture](../contribute/development-guide/coding/01-architecture.md) are, and how they can be used in a REST API. 

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -10,7 +10,7 @@ async function createConfig() {
   return {
     title: 'Template FastAPI React',
     tagline: 'A solution template for creating a Single Page App (SPA) with React and FastAPI following the principles of Clean Architecture.',
-    url: 'https://template-fastapi-react.app.radix.equinor.com/',
+    url: 'https://template-fastapi-react.app.playground.radix.equinor.com/',
     baseUrl: '/template-fastapi-react/',
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
@@ -77,12 +77,12 @@ async function createConfig() {
             },
             { to: '/docs/changelog', label: 'Changelog', position: 'left' },
             {
-              href: 'https://template-fastapi-react.app.radix.equinor.com',
+              href: 'https://template-fastapi-react.app.playground.radix.equinor.com',
               label: 'Demo',
               position: 'right',
             },
             {
-              href: 'https://template-fastapi-react.app.radix.equinor.com/api/docs',
+              href: 'https://template-fastapi-react.app.playground.radix.equinor.com/api/docs',
               label: 'API',
               position: 'right',
             },
@@ -126,7 +126,7 @@ async function createConfig() {
                 },
                 {
                   label: 'Template FastAPI React',
-                  href: 'https://template-fastapi-react.app.radix.equinor.com/',
+                  href: 'https://template-fastapi-react.app.playground.radix.equinor.com/',
                 },
               ],
             },


### PR DESCRIPTION
## Why is this pull request needed?

* The template is a demo that can run in the Radix playground, then it does not need to have any configuration item (application registered in services@equinor)

## What does this pull request change?

* Change ouath redirect URL to point to radix playground
* Change links in docs to point to radix playground

## Issues related to this change: