### PR TITLE
Login as the service principal to request an access token

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,9 +8,6 @@ on:
         default: 'test'
         required: true
         type: string
-    secrets:
-      APP_SERVICE_ACCOUNT_TOKEN:
-        required: true
 
 env:
   RADIX_APP: heracles
@@ -21,10 +18,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
+      - name: Az CLI login
+        uses: azure/login@v1
+        with:
+          client-id: 4a761bec-628d-4c4b-860a-4903cbecc963 #app registration Application ID
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      - name: Get Azure principal token for Radix
+        # The resource 6dae42f8-4368-4678-94ff-3960e28e3630 is a fixed Application ID,
+        # corresponding to the Azure Kubernetes Service AAD Server.
+        run: |
+          token=$(az account get-access-token --resource 6dae42f8-4368-4678-94ff-3960e28e3630 --query=accessToken -otsv)
+          echo "::add-mask::$token"
+          echo "APP_SERVICE_ACCOUNT_TOKEN=$token" >> $GITHUB_ENV   
+
       - name: Deploy on Radix
         uses: equinor/radix-github-actions@master
         env:
-          APP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.APP_SERVICE_ACCOUNT_TOKEN }}
+          APP_SERVICE_ACCOUNT_TOKEN: ${{ env.APP_SERVICE_ACCOUNT_TOKEN }}
         with:
           args: >
             create job

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,5 +25,3 @@ jobs:
     needs: release-please
     uses: ./.github/workflows/release-production.yaml
     if: ${{ needs.release-please.outputs.release_created }}
-    secrets:
-      APP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.APP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/release-production.yaml
+++ b/.github/workflows/release-production.yaml
@@ -3,9 +3,6 @@ name: release-to-production
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      APP_SERVICE_ACCOUNT_TOKEN:
-        required: true
 
 jobs:
   tests:
@@ -23,5 +20,3 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       radix-environment: 'prod'
-    secrets:
-      APP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.APP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
## Why is this pull request needed?

Machine user token are deprecated.

## What does this pull request change?

Login as the service principal with request of an access token, which can be used with Radix CLI/Radix API.

## Issues related to this change: