### PR TITLE
ci: remove secret as input to reusable workflow

### DIFF
--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -33,5 +33,3 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       radix-environment: 'test'
-    secrets:
-      APP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.APP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
## Why is this pull request needed?

* Main branch fails

## What does this pull request change?

* Remove secret as input to deploy, since this is not used anymore

## Issues related to this change: