### PR TITLE
refactor: move fetch-logic to custom hook to separate responsibilities

### DIFF
--- a/web/src/common/components/VersionText.tsx
+++ b/web/src/common/components/VersionText.tsx
@@ -35,23 +35,21 @@ const useCommitInfo = () => {
   return commitInfo
 }
 
-export const VersionText = (): JSX.Element => {
+export const VersionText = () => {
   const commitInfo = useCommitInfo()
 
   return (
     <p>
       Version:{' '}
-      {commitInfo.hash !== '' && commitInfo.date !== '' && (
-        <>
-          <Typography
-            link
-            href={`https://github.com/equinor/template-fastapi-react/commit/${commitInfo.hash}`}
-          >
-            {commitInfo.refs === '' ? commitInfo.hash : commitInfo.refs}
-          </Typography>{' '}
-          ({commitInfo.date})
-        </>
-      )}
+      <>
+        <Typography
+          link
+          href={`https://github.com/equinor/template-fastapi-react/commit/${commitInfo.hash}`}
+        >
+          {commitInfo.refs === '' ? commitInfo.hash : commitInfo.refs}
+        </Typography>{' '}
+        {commitInfo.date}
+      </>
     </p>
   )
 }

--- a/web/src/common/components/VersionText.tsx
+++ b/web/src/common/components/VersionText.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@equinor/eds-core-react'
-import axios, { AxiosResponse } from 'axios'
+import axios, { AxiosError, AxiosResponse } from 'axios'
 import { useEffect, useState } from 'react'
 
 type CommitInfo = {
@@ -16,12 +16,20 @@ const useCommitInfo = () => {
   })
 
   useEffect(() => {
-    axios.get('version.txt').then((response: AxiosResponse<string>) => {
-      const versionFile: { [key: string]: string } = Object.fromEntries(
-        response.data.split('\n').map((line) => line.split(': '))
-      )
-      setCommitInfo(versionFile as CommitInfo)
-    })
+    const fetchVersionFile = () =>
+      axios
+        .get('version.txt')
+        .then((res: AxiosResponse<string>) =>
+          Object.fromEntries(
+            res.data.split('\n').map((line) => line.split(': '))
+          )
+        )
+        .catch((error: AxiosError) => {
+          throw new Error(
+            `Could not read version file, ${error.response?.data ?? error}`
+          )
+        })
+    fetchVersionFile().then((commitInfo) => setCommitInfo(commitInfo))
   }, [])
 
   return commitInfo

--- a/web/src/common/components/VersionText.tsx
+++ b/web/src/common/components/VersionText.tsx
@@ -2,8 +2,14 @@ import { Typography } from '@equinor/eds-core-react'
 import axios, { AxiosResponse } from 'axios'
 import { useEffect, useState } from 'react'
 
+type CommitInfo = {
+  hash: string
+  date: string
+  refs: string
+}
+
 const useCommitInfo = () => {
-  const [commitInfo, setCommitInfo] = useState<{ [key: string]: string }>({
+  const [commitInfo, setCommitInfo] = useState<CommitInfo>({
     hash: '',
     date: '',
     refs: '',
@@ -14,7 +20,7 @@ const useCommitInfo = () => {
       const versionFile: { [key: string]: string } = Object.fromEntries(
         response.data.split('\n').map((line) => line.split(': '))
       )
-      setCommitInfo(versionFile)
+      setCommitInfo(versionFile as CommitInfo)
     })
   }, [])
 

--- a/web/src/common/components/VersionText.tsx
+++ b/web/src/common/components/VersionText.tsx
@@ -1,8 +1,8 @@
 import { Typography } from '@equinor/eds-core-react'
-import { useEffect, useState } from 'react'
 import axios, { AxiosResponse } from 'axios'
+import { useEffect, useState } from 'react'
 
-export const VersionText = (): JSX.Element => {
+const useCommitInfo = () => {
   const [commitInfo, setCommitInfo] = useState<{ [key: string]: string }>({
     hash: '',
     date: '',
@@ -14,14 +14,18 @@ export const VersionText = (): JSX.Element => {
       .get('version.txt')
       .then((response: AxiosResponse<string>) => {
         const versionFile: { [key: string]: string } = Object.fromEntries(
-          response.data.split('\n').map((line) => {
-            return line.split(': ')
-          })
+          response.data.split('\n').map((line) => line.split(': '))
         )
         setCommitInfo(versionFile)
       })
       .catch(() => null)
   }, [])
+
+  return commitInfo
+}
+
+export const VersionText = (): JSX.Element => {
+  const commitInfo = useCommitInfo()
 
   return (
     <p>

--- a/web/src/common/components/VersionText.tsx
+++ b/web/src/common/components/VersionText.tsx
@@ -10,15 +10,12 @@ const useCommitInfo = () => {
   })
 
   useEffect(() => {
-    axios
-      .get('version.txt')
-      .then((response: AxiosResponse<string>) => {
-        const versionFile: { [key: string]: string } = Object.fromEntries(
-          response.data.split('\n').map((line) => line.split(': '))
-        )
-        setCommitInfo(versionFile)
-      })
-      .catch(() => null)
+    axios.get('version.txt').then((response: AxiosResponse<string>) => {
+      const versionFile: { [key: string]: string } = Object.fromEntries(
+        response.data.split('\n').map((line) => line.split(': '))
+      )
+      setCommitInfo(versionFile)
+    })
   }, [])
 
   return commitInfo


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because we don't want to break **SOLID** principles. (Single Responsibility Principle)

## What does this pull request change?
* Throws a more meaningful error if there's problems reading the version file
* Adds `type CommitInfo` to get better documentation of the code
* Separates responsibilities - rendering of the JSX component and fetching data
* Increases testability of `VersionText.tsx`, reducing the need of conditional rendering (potentially slightly better performance), making the code adaptable to changes.

Ideally, I'd like the component to be even more independent of the fetch, but after I added the new error message, I noticed that the endpoint threw 404, and it'd be nice to see the what a successful response looked like. I think it makes sense to try to fix that first, and then continue the refactoring after. #188 

Given that the response is expected to be successful, it could be easier to predict what `VersionText.txt` returned if `commitInfo` was undefined initially. That way, the fetch-function would bear the whole responsibility for handling the fetch-response. We could have confidence that the only reason for `commitInfo` to appear missing in the JSX component, is that it _doesn't exist_, and not because it fails to handle the fetch-response (it shouldn't be responsible for that). Ternary operators checking for `''` could at least be replaced by nullish coalescing operators, resulting in one less option for what the output might be. Maybe it's possible to remove conditionals altogether, depending on what a typical response look like.