### PR TITLE
ci: Add rollback workflow

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -7,6 +7,9 @@ on:
       release_created:
         description: "If true, a release PR has been merged"
         value: ${{ jobs.release-please.outputs.release_created }}
+      tag_name:
+        description: "The release tag. Ex v1.4.0"
+        value: ${{ jobs.release-please.outputs.tag_name }}
 
 jobs:
   release-please:
@@ -23,3 +26,4 @@ jobs:
           changelog-types: '[{ "type": "feat", "section": "Features", "hidden": false },{ "type": "feature", "section": "Features", "hidden": false },{ "type": "fix", "section": "Bug Fixes", "hidden": false },{ "type": "perf", "section": "Performance Improvements", "hidden": false },{ "type": "revert", "section": "Reverts", "hidden": false },{ "type": "docs", "section": "Documentation", "hidden": false },{ "type": "style", "section": "Styles", "hidden": false },{ "type": "chore", "section": "Miscellaneous Chores", "hidden": false },{ "type": "refactor", "section": "Code Refactoring", "hidden": false },{ "type": "test", "section": "Tests", "hidden": false },{ "type": "build", "section": "Build System", "hidden": false },{ "type": "ci", "section": "Continuous Integration", "hidden": false }]'
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/deploy-to-radix.yaml
+++ b/.github/workflows/deploy-to-radix.yaml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      # You'll need an app registration with a Federated Credential for this to
+      # work. Note that the credential will need to specify a branch name. This
+      # step will therefore fail for all branches not mentioned in the credentials
       - name: Az CLI login
         uses: azure/login@v1
         with:

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -44,7 +44,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/publish-image.yaml
     with:
-      image-tags: production
+      image-tags: production,${{ needs.release-please.outputs.tag_name }}
       oauth-redirect-url: "https://template-fastapi-react.app.playground.radix.equinor.com"
 
   deploy-prod:

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -27,7 +27,7 @@ jobs:
     needs: tests
     uses: ./.github/workflows/publish-image.yaml
     with:
-      image-tag: latest
+      image-tags: latest
       oauth-redirect-url: "https://proxy-template-fastapi-react-test.playground.radix.equinor.com/"
   deploy-test:
     needs: publish-latest
@@ -44,7 +44,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/publish-image.yaml
     with:
-      image-tag: production
+      image-tags: production
       oauth-redirect-url: "https://template-fastapi-react.app.playground.radix.equinor.com"
 
   deploy-prod:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -3,9 +3,8 @@ on:
   workflow_dispatch:
   workflow_call: # Workflow is meant to be called from another workflow, with the image tag as input
     inputs:
-      image-tag:
-        description: "Which tag to set for the produced docker images"
-        default: "latest"
+      image-tags:
+        description: "Which tag to give the images. Supports multiple tags if comma separated, ie 'tag1,tag2'"
         required: true
         type: string
       oauth-redirect-url:
@@ -36,9 +35,8 @@ jobs:
       - name: "Login to image registry"
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
 
-      - name: "Build and Publish Web"
+      - name: "Build web"
         run: |
-          echo "Tagging with ${{ inputs.image-tag }}"
           docker pull $WEB_IMAGE
           printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./web/public/version.txt
           docker build \
@@ -50,8 +48,16 @@ jobs:
           --cache-from ${WEB_IMAGE} \
           --tag ${WEB_IMAGE} \
           ./web
-          docker tag $WEB_IMAGE $WEB_IMAGE:${{ inputs.image-tag }}
-          docker push $WEB_IMAGE:${{ inputs.image-tag }}
+
+      - name: "Publish web"
+        run: |
+          IFS=','
+          for IMAGE_TAG in $(echo ${{ inputs.image-tags }})
+          do
+            echo "Tagging with $IMAGE_TAG"
+            docker tag $WEB_IMAGE $WEB_IMAGE:$IMAGE_TAG
+            docker push $WEB_IMAGE:$IMAGE_TAG
+          done
 
   build-and-publish-api-main:
     runs-on: ubuntu-latest
@@ -63,14 +69,21 @@ jobs:
       - name: "Login to image registry"
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
 
-      - name: "Build and Publish API"
+      - name: "Build API"
         run: |
-          echo "Tagging with ${{ inputs.image-tag }}"
           docker pull $API_IMAGE
           printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./api/src/version.txt
           docker build --cache-from $API_IMAGE --target prod --tag $API_IMAGE ./api
-          docker tag $API_IMAGE $API_IMAGE:${{ inputs.image-tag }}
-          docker push $API_IMAGE:${{ inputs.image-tag }}
+
+      - name: "Publish API"
+        run: |
+          IFS=','
+          for IMAGE_TAG in $(echo ${{ inputs.image-tags }})
+          do
+            echo "Tagging with $IMAGE_TAG"
+            docker tag $API_IMAGE $API_IMAGE:$IMAGE_TAG
+            docker push $API_IMAGE:$IMAGE_TAG
+          done
 
   build-and-publish-nginx:
     runs-on: ubuntu-latest
@@ -80,10 +93,17 @@ jobs:
       - name: "Login to image registry"
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
 
-      - name: "Build and Publish nginx"
+      - name: "Build nginx"
         run: |
-          echo "Tagging with ${{ inputs.image-tag }}"
           docker pull $NGINX_IMAGE
           docker build --cache-from $NGINX_IMAGE --tag $NGINX_IMAGE ./nginx
-          docker tag $NGINX_IMAGE $NGINX_IMAGE:${{ inputs.image-tag }}
-          docker push $NGINX_IMAGE:${{ inputs.image-tag }}
+
+      - name: "Publish nginx"
+        run: |
+          IFS=','
+          for IMAGE_TAG in $(echo ${{ inputs.image-tags }})
+          do
+            echo "Tagging with $IMAGE_TAG"
+            docker tag $NGINX_IMAGE $NGINX_IMAGE:$IMAGE_TAG
+            docker push $NGINX_IMAGE:$IMAGE_TAG
+          done

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -33,10 +33,12 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: "Login to image registry"
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+
       - name: "Build and Publish Web"
         run: |
           echo "Tagging with ${{ inputs.image-tag }}"
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull $WEB_IMAGE
           printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./web/public/version.txt
           docker build \
@@ -58,10 +60,12 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: "Login to image registry"
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+
       - name: "Build and Publish API"
         run: |
           echo "Tagging with ${{ inputs.image-tag }}"
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull $API_IMAGE
           printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./api/src/version.txt
           docker build --cache-from $API_IMAGE --target prod --tag $API_IMAGE ./api
@@ -72,10 +76,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
+      - name: "Login to image registry"
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+
       - name: "Build and Publish nginx"
         run: |
           echo "Tagging with ${{ inputs.image-tag }}"
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull $NGINX_IMAGE
           docker build --cache-from $NGINX_IMAGE --tag $NGINX_IMAGE ./nginx
           docker tag $NGINX_IMAGE $NGINX_IMAGE:${{ inputs.image-tag }}

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -28,11 +28,12 @@ jobs:
             ghcr.io/equinor/template-fastapi-react/nginx,
           ]
     steps:
-      - uses: actions/checkout@master
+      - name: "Login to image registry"
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+
       - name: "Set prod tag on older image"
         run: |
           echo "Tagging ${{ matrix.image }}:${{ inputs.release-tag }} with 'production'"
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull ${{ matrix.image }}:${{ inputs.release-tag }}
           docker tag ${{ matrix.image }}:${{ inputs.release-tag }} ${{ matrix.image }}:production
           docker push $API_IMAGE:production

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -1,0 +1,44 @@
+name: "Rollback prod to an older release"
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "GitHub release tag. Must match a Docker image tag"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+env:
+  IMAGE_REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/equinor/neqsimapi
+
+jobs:
+  set-prod-tag:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          [
+            ghcr.io/equinor/template-fastapi-react/api,
+            ghcr.io/equinor/template-fastapi-react/web,
+            ghcr.io/equinor/template-fastapi-react/nginx,
+          ]
+    steps:
+      - uses: actions/checkout@master
+      - name: "Set prod tag on older image"
+        run: |
+          echo "Tagging ${{ matrix.image }}:${{ inputs.release-tag }} with 'production'"
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+          docker pull ${{ matrix.image }}:${{ inputs.release-tag }}
+          docker tag ${{ matrix.image }}:${{ inputs.release-tag }} ${{ matrix.image }}:production
+          docker push $API_IMAGE:production
+
+  deploy:
+    needs: set-prod-tag
+    uses: ./.github/workflows/deploy-to-radix.yaml
+    with:
+      radix-environment: "prod"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,9 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: "Login to image registry"
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+
       - name: Build API image
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull $API_IMAGE
           docker build --target development --tag api-development ./api # TODO: --cache-from $API_IMAGE
 
@@ -62,9 +64,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: "Login to image registry"
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
+
       - name: Build Web Image
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $GITHUB_ACTOR --password-stdin
           docker pull $WEB_IMAGE
           docker build --cache-from $WEB_IMAGE --target development --tag web-dev ./web
 


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because sometimes we might publish buggy code to prod and will need to roll back to a stable version. We might be in a hurry, so it's nice to have the rollback functionality ready

## What does this pull request change?

- Adds a rollback workflow
- Update the publish-image workflow to add release tags to the images as well as "production"
- Refactor and document

## Issues related to this change:

Closes #153