### PR TITLE
refactor: move dependency to API to useTodoAPI hook

### DIFF
--- a/web/src/features/todos/todo-list/TodoItem.tsx
+++ b/web/src/features/todos/todo-list/TodoItem.tsx
@@ -6,38 +6,23 @@ import {
   Typography,
 } from '@equinor/eds-core-react'
 import { done, remove_outlined, undo } from '@equinor/eds-icons'
-import { AxiosError } from 'axios'
-import { AddTodoResponse, ErrorResponse } from '../../../api/generated'
+import { AddTodoResponse } from '../../../api/generated'
 import { useTodos } from '../../../contexts/TodoContext'
 import { useTodoAPI } from '../../../hooks/useTodoAPI'
 import { StyledTodoItemTitle } from './TodoItem.styled'
 
 const TodoItem = ({ todo }: { todo: AddTodoResponse }) => {
-  const todoAPI = useTodoAPI()
+  const { toggleTodo, removeTodo } = useTodoAPI()
   const { dispatch } = useTodos()
 
-  function toggleTodo(todo: AddTodoResponse) {
-    todoAPI
-      .updateById({
-        id: todo.id,
-        updateTodoRequest: {
-          is_completed: !todo.is_completed,
-          title: todo.title,
-        },
-      })
-      .catch((error: AxiosError<ErrorResponse>) => {
-        throw new Error(error.message)
-      })
-      .then(() => dispatch({ type: 'TOGGLE_TODO', payload: todo }))
+  async function toggle(todo: AddTodoResponse) {
+    await toggleTodo(todo)
+    dispatch({ type: 'TOGGLE_TODO', payload: todo })
   }
 
-  function removeTodo(todo: AddTodoResponse) {
-    todoAPI
-      .deleteById({ id: todo.id })
-      .catch((error: AxiosError<ErrorResponse>) => {
-        throw new Error(error.message)
-      })
-      .then(() => dispatch({ type: 'REMOVE_TODO', payload: todo }))
+  async function remove(todo: AddTodoResponse) {
+    await removeTodo(todo)
+    dispatch({ type: 'REMOVE_TODO', payload: todo })
   }
 
   return (
@@ -56,7 +41,7 @@ const TodoItem = ({ todo }: { todo: AddTodoResponse }) => {
           </Typography>
         </Card.HeaderTitle>
         <Tooltip title={`Mark as ${todo.is_completed ? 'incomplete' : 'done'}`}>
-          <Button variant="ghost_icon" onClick={() => toggleTodo(todo)}>
+          <Button variant="ghost_icon" onClick={() => toggle(todo)}>
             <Icon
               data={todo.is_completed ? undo : done}
               size={24}
@@ -65,7 +50,7 @@ const TodoItem = ({ todo }: { todo: AddTodoResponse }) => {
           </Button>
         </Tooltip>
         <Tooltip title="Remove">
-          <Button variant="ghost_icon" onClick={() => removeTodo(todo)}>
+          <Button variant="ghost_icon" onClick={() => remove(todo)}>
             <Icon data={remove_outlined} size={24} title="Remove" />
           </Button>
         </Tooltip>

--- a/web/src/features/todos/todo-list/TodoList.tsx
+++ b/web/src/features/todos/todo-list/TodoList.tsx
@@ -1,34 +1,29 @@
 import { Button, Input } from '@equinor/eds-core-react'
-import { AxiosError } from 'axios'
 import { FormEventHandler, useEffect, useState } from 'react'
-import { AddTodoResponse, ErrorResponse } from '../../../api/generated'
+import { AddTodoResponse } from '../../../api/generated'
 import { useTodos } from '../../../contexts/TodoContext'
 import { useTodoAPI } from '../../../hooks/useTodoAPI'
 import TodoItem from './TodoItem'
 import { StyledInput, StyledTodoList } from './TodoList.styled'
 
 const AddItem = () => {
-  const todoAPI = useTodoAPI()
+  const { addTodo } = useTodoAPI()
   const { dispatch } = useTodos()
   const [value, setValue] = useState('')
 
-  const addTodo: FormEventHandler = (event) => {
+  const add: FormEventHandler = (event) => {
     event.preventDefault()
     if (value) {
-      todoAPI
-        .create({ addTodoRequest: { title: value } })
-        .then((response) => response.data)
-        .catch((error: AxiosError<ErrorResponse>) => {
-          throw new Error(error.message)
-        })
-        .then((todo) => dispatch({ type: 'ADD_TODO', payload: todo }))
+      addTodo(value).then((todo) =>
+        dispatch({ type: 'ADD_TODO', payload: todo })
+      )
     }
     setValue('')
   }
 
   return (
     <div className="form">
-      <form onSubmit={addTodo}>
+      <form onSubmit={add}>
         <StyledInput>
           <Input
             value={value}
@@ -46,24 +41,14 @@ const AddItem = () => {
 }
 
 const TodoList = () => {
-  const todoAPI = useTodoAPI()
+  const { getAllTodos } = useTodoAPI()
   const { state, dispatch } = useTodos()
 
   useEffect(() => {
-    function fetchTodos() {
-      const todos = todoAPI
-        .getAll()
-        .then((response) => response.data)
-        .catch((error: AxiosError<ErrorResponse>) => {
-          throw new Error(error.message)
-        })
-      return todos
-    }
-
-    fetchTodos().then((todos) =>
+    getAllTodos().then((todos) =>
       dispatch({ type: 'INITIALIZE', payload: todos })
     )
-  }, [dispatch, todoAPI])
+  }, [dispatch, getAllTodos])
 
   return (
     <StyledTodoList>

--- a/web/src/hooks/useTodoAPI.tsx
+++ b/web/src/hooks/useTodoAPI.tsx
@@ -1,5 +1,7 @@
-import { useContext, useEffect, useState } from 'react'
+import { AxiosError } from 'axios'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
+import { AddTodoResponse, ErrorResponse } from '../api/generated'
 import TodoAPI from '../api/TodoAPI'
 
 export function useTodoAPI() {
@@ -10,5 +12,56 @@ export function useTodoAPI() {
     setTodoAPI(new TodoAPI(token))
   }, [token])
 
-  return todoAPI
+  const addTodo = useCallback(
+    (title: string) => {
+      const todo = todoAPI
+        .create({ addTodoRequest: { title: title } })
+        .then((response) => response.data)
+        .catch((error: AxiosError<ErrorResponse>) => {
+          throw new Error(error.message)
+        })
+      return todo
+    },
+    [todoAPI]
+  )
+
+  const getAllTodos = useCallback(() => {
+    const todos = todoAPI
+      .getAll()
+      .then((response) => response.data)
+      .catch((error: AxiosError<ErrorResponse>) => {
+        throw new Error(error.message)
+      })
+    return todos
+  }, [todoAPI])
+
+  const toggleTodo = useCallback(
+    async (todo: AddTodoResponse) => {
+      todoAPI
+        .updateById({
+          id: todo.id,
+          updateTodoRequest: {
+            is_completed: !todo.is_completed,
+            title: todo.title,
+          },
+        })
+        .catch((error: AxiosError<ErrorResponse>) => {
+          throw new Error(error.message)
+        })
+    },
+    [todoAPI]
+  )
+
+  const removeTodo = useCallback(
+    async (todo: AddTodoResponse) => {
+      todoAPI
+        .deleteById({ id: todo.id })
+        .catch((error: AxiosError<ErrorResponse>) => {
+          throw new Error(error.message)
+        })
+    },
+    [todoAPI]
+  )
+
+  return { todoAPI, addTodo, getAllTodos, toggleTodo, removeTodo }
 }


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because separation of concerns 😄

## What does this pull request change?

Moves dependency to api from the jsx-components to the custom hook `useTodoAPI`. Fetching and state handling were previously nested together in `useTodos` until state handling got separated in #193. Fetch-logic got temporarily moved to the components that consumed them until this PR.

## Issues related to this change:
#193 