### PR TITLE
refactor: show changelog types using multi-line strings

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -23,7 +23,22 @@ jobs:
           extra-files: |
             api/pyproject.toml
             api/src/app.py
-          changelog-types: '[{ "type": "feat", "section": "Features", "hidden": false },{ "type": "feature", "section": "Features", "hidden": false },{ "type": "fix", "section": "Bug Fixes", "hidden": false },{ "type": "perf", "section": "Performance Improvements", "hidden": false },{ "type": "revert", "section": "Reverts", "hidden": false },{ "type": "docs", "section": "Documentation", "hidden": false },{ "type": "style", "section": "Styles", "hidden": false },{ "type": "chore", "section": "Miscellaneous Chores", "hidden": false },{ "type": "refactor", "section": "Code Refactoring", "hidden": false },{ "type": "test", "section": "Tests", "hidden": false },{ "type": "build", "section": "Build System", "hidden": false },{ "type": "ci", "section": "Continuous Integration", "hidden": false }]'
+          changelog-types: >
+            [
+               { "type": "feat", "section": "Features", "hidden": false },
+               { "type": "feature", "section": "Features", "hidden": false},
+               { "type": "fix", "section": "Bug Fixes", "hidden": false },
+               { "type": "perf", "section": "Performance Improvements", "hidden": false },
+               { "type": "revert", "section": "Reverts", "hidden": false },
+               { "type": "docs", "section": "Documentation", "hidden": false },
+               { "type": "style", "section": "Styles", "hidden": false },
+               { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+               { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+               { "type": "test", "section": "Tests", "hidden": false },
+               { "type": "build", "section": "Build System", "hidden": false },
+               { "type": "ci", "section": "Continuous Integration", "hidden": false }
+            ]
+
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Why is this pull request needed?

* Easier to see how changelog-types are configured

## What does this pull request change?

* Single-line to multi-line configuration of changelog types

## Issues related to this change: