### PR TITLE
refactor: header

### DIFF
--- a/web/src/common/components/Header.tsx
+++ b/web/src/common/components/Header.tsx
@@ -1,7 +1,8 @@
-import { Button, Icon, TopBar, Typography } from '@equinor/eds-core-react'
+import { Icon, TopBar, Typography } from '@equinor/eds-core-react'
 import { info_circle, log_out, receipt } from '@equinor/eds-icons'
 import { useContext, useRef, useState } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
+import IconButton from './IconButton'
 import Popover from './Popover'
 import { VersionText } from './VersionText'
 
@@ -27,27 +28,17 @@ const Header = () => {
           {tokenData ? (
             <>
               <Typography>Logged in as {username}</Typography>
-              <Button
-                variant="ghost_icon"
-                aria-label="Log out"
-                title="Log out"
-                onClick={logOut}
-              >
-                <Icon data={log_out} title="Log out" />
-              </Button>
+              <IconButton title={'Log out'} icon={log_out} onClick={logOut} />
             </>
           ) : (
             <Typography variant="caption">Unauthenticated</Typography>
           )}
-          <Button
-            variant="ghost_icon"
-            aria-label="Application info"
-            title="Application info"
+          <IconButton
+            title={'Application info'}
+            icon={info_circle}
             onClick={togglePopover}
             ref={aboutRef}
-          >
-            <Icon data={info_circle} />
-          </Button>
+          />
         </TopBar.Actions>
       </TopBar>
       <Popover

--- a/web/src/common/components/Header.tsx
+++ b/web/src/common/components/Header.tsx
@@ -25,14 +25,8 @@ const Header = () => {
           Todo App
         </TopBar.Header>
         <TopBar.Actions style={{ gap: 8 }}>
-          {tokenData ? (
-            <>
-              <Typography>Logged in as {username}</Typography>
-              <IconButton title={'Log out'} icon={log_out} onClick={logOut} />
-            </>
-          ) : (
-            <Typography variant="caption">Unauthenticated</Typography>
-          )}
+          <Typography>{`Logged in as ${username}`}</Typography>
+          <IconButton title={'Log out'} icon={log_out} onClick={logOut} />
           <IconButton
             title={'Application info'}
             icon={info_circle}

--- a/web/src/common/components/IconButton.tsx
+++ b/web/src/common/components/IconButton.tsx
@@ -1,5 +1,6 @@
 import { Button, Icon, Tooltip } from '@equinor/eds-core-react'
 import { IconData } from '@equinor/eds-icons'
+import { forwardRef, Ref } from 'react'
 
 interface IconButtonProps {
   title: string
@@ -7,14 +8,19 @@ interface IconButtonProps {
   onClick: () => Promise<void>
 }
 
-const IconButton = ({ title, icon, onClick }: IconButtonProps) => {
-  return (
-    <Tooltip title={title}>
-      <Button variant="ghost_icon" onClick={onClick}>
-        <Icon data={icon} size={24} title={title} />
-      </Button>
-    </Tooltip>
-  )
-}
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton(
+    { title, icon, onClick }: IconButtonProps,
+    ref: Ref<HTMLButtonElement>
+  ) {
+    return (
+      <Tooltip title={title}>
+        <Button variant="ghost_icon" onClick={onClick} ref={ref}>
+          <Icon data={icon} size={24} title={title} />
+        </Button>
+      </Tooltip>
+    )
+  }
+)
 
 export default IconButton

--- a/web/src/common/components/IconButton.tsx
+++ b/web/src/common/components/IconButton.tsx
@@ -5,7 +5,7 @@ import { forwardRef, Ref } from 'react'
 interface IconButtonProps {
   title: string
   icon: IconData
-  onClick: () => Promise<void>
+  onClick: () => Promise<void> | void
 }
 
 const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(


### PR DESCRIPTION
## What does this pull request change?

Cleans up the code in `Header.tsx`:
- Uses `IconButton` introduced in #201 to remove repeated code in `Header`
- Forwards ref to `IconButton` to be able to anchor Popover (#204)
- Removes conditional render in `Header`

### Telling authenticated users that they're unauthenticated 🤔
This piece of code renders `Unauthenticated` and then re-renders to `Logged in as ..` without requiring any log in in between. I had a look at the auth config in `App.tsx`, and it seems you shouldn't be able to render `Header` at all if you're not already authenticated. Meaning this conditional render is kinda redundant and will only cause unnecessary re-renders.

```typescript
{tokenData ? (
            <>
              <Typography>Logged in as {username}</Typography>
              <Button
                variant="ghost_icon"
                aria-label="Log out"
                title="Log out"
                onClick={logOut}
              >
                <Icon data={log_out} title="Log out" />
              </Button>
            </>
          ) : (
            <Typography variant="caption">Unauthenticated</Typography>
          )}
```
