### PR TITLE
refactor: rewrite logger middleware to be a 'pure ASGI' middleware

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -5,7 +5,7 @@ from starlette.middleware import Middleware
 
 from authentication.authentication import auth_with_jwt
 from common.exception_handlers import validation_exception_handler
-from common.middleware import TimerHeaderMiddleware
+from common.middleware import LocalLoggerMiddleware
 from common.responses import responses
 from config import config
 from features.health_check import health_check_feature
@@ -35,7 +35,7 @@ def create_app() -> FastAPI:
     authenticated_routes.include_router(todo_feature.router)
     authenticated_routes.include_router(whoami_feature.router)
 
-    middleware = [Middleware(TimerHeaderMiddleware)]
+    middleware = [Middleware(LocalLoggerMiddleware)]
 
     exception_handlers = {RequestValidationError: validation_exception_handler}
 


### PR DESCRIPTION
This fixes an issue caused by our middleware, that was implemented in a way making them incompatible with Starlettes BackgroundTasks (see: https://github.com/encode/starlette/issues/919).
The refactored middleware is now written as a "pure ASGI middleware" (see: https://www.starlette.io/middleware/#pure-asgi-middleware)