### PR TITLE
Fix/pydantic to openapi

### DIFF
--- a/api/src/authentication/models.py
+++ b/api/src/authentication/models.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
-from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, GetJsonSchemaHandler
+from pydantic_core import core_schema
 
 
 class AccessLevel(IntEnum):
@@ -28,7 +28,7 @@ class AccessLevel(IntEnum):
             raise ValueError("invalid AccessLevel enum value ")
 
     @classmethod
-    def __get_pydantic_json_schema__(cls, schema: dict[str, Any]):
+    def __get_pydantic_json_schema__(cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler):
         """
         Add a custom field type to the class representing the Enum's field names
         Ref: https://pydantic-docs.helpmanual.io/usage/schema/#modifying-schema-in-custom-fields
@@ -37,7 +37,9 @@ class AccessLevel(IntEnum):
         to provide names for the Enum values.
         Ref: https://openapi-generator.tech/docs/templating/#enum
         """
-        schema["x-enum-varnames"] = [choice.name for choice in cls]
+        json_schema = handler(core_schema)
+        json_schema["x-enum-varnames"] = [choice.name for choice in cls]
+        return json_schema
 
 
 class User(BaseModel):


### PR DESCRIPTION
## Why is this pull request needed?

* Generate OpenAPI specification fails

## What does this pull request change?

Extending or overriding the generated JSON schema in a model is possible by implementing __get_pydantic_json_schema__ on your model.  Just need to update the arguments, since that seems to have changed.


> **NOTE**: Docs can be found at https://docs.pydantic.dev/latest/usage/json_schema/

## Issues related to this change: