### PR TITLE
ci: avoid future mistake

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -96,8 +96,12 @@ ignore = [
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]  # Ignore `E402` (import violations) in all `__init__.py` files
-"locustfile.py" = ["B012"]  # B012 `break` inside `finally` blocks cause exceptions to be silenced
 
 [tool.codespell]
 skip = "*.lock,*.cjs"
 ignore-words-list = "ignored-word"
+
+[tool.pytest]
+markers =[
+    "integration: mark a test as integration test."
+]

--- a/api/src/pytest.ini
+++ b/api/src/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    integration: mark a test as integration test.

--- a/api/src/tests/conftest.py
+++ b/api/src/tests/conftest.py
@@ -78,5 +78,5 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
-    if "integration" in item.keywords and not item.config.getvalue("integration"):
+    if "integration" in item.keywords and not item.config.getoption("integration"):
         pytest.skip("need --integration option to run")

--- a/web/generate-api-typescript-client-pre-commit.sh
+++ b/web/generate-api-typescript-client-pre-commit.sh
@@ -14,6 +14,36 @@ if [ ${#CHANGED_API_FILES[@]} -eq 0 ]; then
 else
     echo "Changes detected in API relevant files. Generating API ..."
     # This requires the API to be running on localhost port 5000
-    cd web
-    yarn openapi -i http://localhost:5000/openapi.json -o "$PWD/src/api/generated"
+    # Define the URL of the OpenAPI specification
+    OPENAPI_URL="http://0.0.0.0:5000/openapi.json"
+
+    # Use curl to fetch the OpenAPI specification and store it in a temporary file
+    TEMP_FILE=$(mktemp)
+    curl -s "$OPENAPI_URL" > "$TEMP_FILE"
+
+    # Check if the curl command was successful
+    if [ $? -ne 0 ]; then
+      echo "Failed to fetch the OpenAPI specification."
+      rm "$TEMP_FILE"
+      exit 1
+    fi
+
+    # Use grep to extract the name from the OpenAPI specification
+    NAME=$(grep -o -s '"title": *"[^"]*"' "$TEMP_FILE" | head -1 | awk -F '"' '{print $4}')
+
+    # Check if the name is empty or null
+    if [ -z "$NAME" ]; then
+      echo "Name of API not found in the OpenAPI specification."
+      exit 1
+    elif [ "$NAME" != "Template FastAPI React" ]; then
+      echo "The openapi specification found at localhost:5000 ('$NAME') does not seem to belong to 'Template FastAPI React'"
+      exit 1
+    else
+      cd web
+      yarn openapi -i http://localhost:5000/openapi.json -o "$PWD/src/api/generated"
+      echo "API Client successfully generated"
+    fi
+
+    # Clean up the temporary file
+    rm "$TEMP_FILE"
 fi


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because the wrong typescript client got pushed by accident. Avoid this mistake in the future

## What does this pull request change?

Check that the correct openapi spec is used to generate the typescript client
