### PR TITLE
fix: make authentication work again

### DIFF
--- a/api/src/authentication/authentication.py
+++ b/api/src/authentication/authentication.py
@@ -44,7 +44,7 @@ def auth_with_jwt(jwt_token: str = Security(oauth2_scheme)) -> User:
     key = mock_rsa_public_key if config.TEST_TOKEN else {"keys": fetch_openid_configuration()["jwks"]}
 
     try:
-        payload = jwt.decode(jwt_token, key, algorithms=["RS256"], audience=config.AUTH_AUDIENCE)
+        payload = jwt.decode(jwt_token, key, algorithms=["RS256"], audience=config.OAUTH_AUDIENCE)
         if config.MICROSOFT_AUTH_PROVIDER in payload["iss"]:
             # Azure AD uses an oid string to uniquely identify users. Each user has a unique oid value.
             user = User(user_id=payload["oid"], **payload)

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -33,7 +33,7 @@ class Config(BaseSettings):
     OAUTH_AUTH_ENDPOINT: str = ""
     OAUTH_CLIENT_ID: str = ""
     OAUTH_AUTH_SCOPE: str = ""
-    AUTH_AUDIENCE: str = ""
+    OAUTH_AUDIENCE: str = ""
     MICROSOFT_AUTH_PROVIDER: str = "login.microsoftonline.com"
 
 


### PR DESCRIPTION
## Why is this pull request needed?

A spelling error was causing the auth audience to be unset, thus making authentication fail.

## What does this pull request change?


## Issues related to this change: