### PR TITLE
tests: change how pytest adds markers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,10 +54,10 @@ jobs:
 
       - name: BDD Integration tests
         if: ${{ false }} # disable for now
-        run: docker-compose -f docker-compose.yml -f docker-compose.ci.yml run api behave
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml run api behave
 
       - name: Pytest Integration tests
-        run: docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm api pytest --integration
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml run --rm api pytest --integration
 
   test-web:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,9 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: trailing-whitespace
-        exclude: ^.*\.(lock)$
+        exclude: ^web/src/api/generated/|^.*\.(lock)$
       - id: end-of-file-fixer
-        exclude: ^.*\.(lock)$
+        exclude: ^web/src/api/generated/|^.*\.(lock)$
       - id: mixed-line-ending
         exclude: ^.*\.(lock)$
       - id: detect-private-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
         language_version: python3.10
@@ -32,13 +32,13 @@ repos:
         stages: [commit-msg]
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.4.7"
+    rev: "v0.6.3"
     hooks:
       - id: ruff
         name: Python lint
@@ -50,10 +50,10 @@ repos:
         files: ^api/.*\.py$
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v0.2.0
+    rev: v0.4.0
     hooks:
       - id: biome-check
-        additional_dependencies: [ "@biomejs/biome@1.8.0" ]
+        additional_dependencies: [ "@biomejs/biome@1.8.3" ]
         args: ["--config-path", "web"]
 
 
@@ -92,6 +92,7 @@ repos:
         name: codespell
         description: Checks for common misspellings in text files.
         entry: codespell --toml=api/pyproject.toml
+        exclude: documentation/docs/changelog/changelog.md
         language: python
         types: [text]
         additional_dependencies:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -91,7 +91,13 @@ ignore = [
 skip = "*.lock,*.cjs"
 ignore-words-list = "ignored-word"
 
-[tool.pytest]
-markers =[
+[tool.pytest.ini_options]
+# Makes pytest CLI discover markers and conftest settings:
+markers = [
+    "unit: mark a test as unit test.",
     "integration: mark a test as integration test."
+]
+testpaths = [
+    "src/tests/unit",
+    "src/tests/integration"
 ]

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -77,7 +77,7 @@ def run() -> None:
         port=5000,
         factory=True,
         reload=config.ENVIRONMENT == "local",
-        log_level=config.LOGGER_LEVEL.lower(),
+        log_level=config.log_level,
     )
 
 

--- a/api/src/authentication/models.py
+++ b/api/src/authentication/models.py
@@ -16,19 +16,6 @@ class AccessLevel(IntEnum):
         return False
 
     @classmethod
-    def __get_validators__(cls):  # type:ignore
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v: str) -> "AccessLevel":
-        if isinstance(v, cls):
-            return v
-        try:
-            return cls[v]
-        except KeyError:
-            raise ValueError("invalid AccessLevel enum value ")
-
-    @classmethod
     def __get_pydantic_json_schema__(
         cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> dict[str, Any]:

--- a/api/src/common/exception_handlers.py
+++ b/api/src/common/exception_handlers.py
@@ -30,7 +30,7 @@ def add_exception_handlers(app: FastAPI) -> None:
 
     # Override built-in default handler
     app.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore
-    app.add_exception_handler(HTTPStatusError, http_exception_handler)  # type: ignore
+    app.add_exception_handler(HTTPStatusError, http_exception_handler)
 
     # Fallback exception handler for all unexpected exceptions
     app.add_exception_handler(Exception, fall_back_exception_handler)

--- a/api/src/common/exceptions.py
+++ b/api/src/common/exceptions.py
@@ -44,7 +44,7 @@ class ApplicationException(Exception):
         self.extra = extra
         self.severity = severity
 
-    def dict(self) -> dict[str, int | str | dict[str, Any] | None]:
+    def to_dict(self) -> dict[str, int | str | dict[str, Any] | None]:
         return {
             "status": self.status,
             "type": self.type,

--- a/api/src/common/logger.py
+++ b/api/src/common/logger.py
@@ -9,9 +9,9 @@ from config import config
 uvicorn_logger = logging.getLogger("uvicorn")
 
 logger = logging.getLogger("API")
-logger.setLevel(config.LOGGER_LEVEL.upper())
+logger.setLevel(config.log_level.upper())
 formatter = logging.Formatter("%(levelname)s:%(asctime)s %(message)s")
 channel = logging.StreamHandler()
 channel.setFormatter(formatter)
-channel.setLevel(config.LOGGER_LEVEL.upper())
+channel.setLevel(config.log_level.upper())
 logger.addHandler(channel)

--- a/api/src/common/logger_level.py
+++ b/api/src/common/logger_level.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class LoggerLevel(Enum):
+    """Enum containing the different levels for logging."""
+
+    CRITICAL = "critical"
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+    DEBUG = "debug"
+    TRACE = "trace"

--- a/api/src/common/responses.py
+++ b/api/src/common/responses.py
@@ -17,7 +17,7 @@ responses: dict[int | str, dict[str, Any]] = {
             "application/json": {
                 "example": ErrorResponse(
                     status=401, type="UnauthorizedException", message="Token validation failed"
-                ).dict()
+                ).model_dump()
             }
         },
     },

--- a/api/src/common/responses.py
+++ b/api/src/common/responses.py
@@ -10,7 +10,7 @@ from common.exceptions import (
 )
 
 responses: dict[int | str, dict[str, Any]] = {
-    400: {"model": ErrorResponse, "content": {"application/json": {"example": BadRequestException().dict()}}},
+    400: {"model": ErrorResponse, "content": {"application/json": {"example": BadRequestException().to_dict()}}},
     401: {
         "model": ErrorResponse,
         "content": {
@@ -21,8 +21,11 @@ responses: dict[int | str, dict[str, Any]] = {
             }
         },
     },
-    403: {"model": ErrorResponse, "content": {"application/json": {"example": MissingPrivilegeException().dict()}}},
-    404: {"model": ErrorResponse, "content": {"application/json": {"example": NotFoundException().dict()}}},
-    422: {"model": ErrorResponse, "content": {"application/json": {"example": ValidationException().dict()}}},
-    500: {"model": ErrorResponse, "content": {"application/json": {"example": ApplicationException().dict()}}},
+    403: {
+        "model": ErrorResponse,
+        "content": {"application/json": {"example": MissingPrivilegeException().to_dict()}},
+    },
+    404: {"model": ErrorResponse, "content": {"application/json": {"example": NotFoundException().to_dict()}}},
+    422: {"model": ErrorResponse, "content": {"application/json": {"example": ValidationException().to_dict()}}},
+    500: {"model": ErrorResponse, "content": {"application/json": {"example": ApplicationException().to_dict()}}},
 }

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -2,6 +2,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 
 from authentication.models import User
+from common.logger_level import LoggerLevel
 
 
 class Config(BaseSettings):
@@ -9,7 +10,7 @@ class Config(BaseSettings):
     ENVIRONMENT: str = "local"
 
     # Logging
-    LOGGER_LEVEL: str = Field("INFO", validation_alias="LOGGING_LEVEL", to_lower=True)
+    LOGGER_LEVEL: LoggerLevel = Field(default=LoggerLevel.INFO)
     APPINSIGHTS_CONSTRING: str | None = None
 
     # Database
@@ -35,6 +36,11 @@ class Config(BaseSettings):
     OAUTH_AUTH_SCOPE: str = ""
     OAUTH_AUDIENCE: str = ""
     MICROSOFT_AUTH_PROVIDER: str = "login.microsoftonline.com"
+
+    @property
+    def log_level(self) -> str:
+        """Returns LOGGER_LEVEL as a (lower case) string."""
+        return str(self.LOGGER_LEVEL.value).lower()
 
 
 config = Config()

--- a/api/src/features/todo/use_cases/add_todo.py
+++ b/api/src/features/todo/use_cases/add_todo.py
@@ -11,13 +11,23 @@ class AddTodoRequest(BaseModel):
         title="The title of the item",
         max_length=300,
         min_length=1,
-        example="Read about clean architecture",
+        json_schema_extra={
+            "examples": ["Read about clean architecture"],
+        },
     )
 
 
 class AddTodoResponse(BaseModel):
-    id: str = Field(example="vytxeTZskVKR7C7WgdSP3d")
-    title: str = Field(example="Read about clean architecture")
+    id: str = Field(
+        json_schema_extra={
+            "examples": ["vytxeTZskVKR7C7WgdSP3d"],
+        }
+    )
+    title: str = Field(
+        json_schema_extra={
+            "examples": ["Read about clean architecture"],
+        }
+    )
     is_completed: bool = False
 
     @staticmethod

--- a/api/src/tests/conftest.py
+++ b/api/src/tests/conftest.py
@@ -50,8 +50,8 @@ def mock_request(
     method: str = "GET",
     server: str = "www.example.com",
     path: str = "/",
-    headers: dict = None,
-    body: str = None,
+    headers: dict | None = None,
+    body: bytes | None = None,
 ) -> Request:
     if headers is None:
         headers = {}

--- a/api/src/tests/integration/common/test_exception_handler.py
+++ b/api/src/tests/integration/common/test_exception_handler.py
@@ -1,8 +1,5 @@
-import pytest
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 from starlette.testclient import TestClient
-
-pytestmark = pytest.mark.integration
 
 
 def test_exception_handler_validation_error(test_app: TestClient):

--- a/api/src/tests/integration/features/health_check/test_health_check_feature.py
+++ b/api/src/tests/integration/features/health_check/test_health_check_feature.py
@@ -1,8 +1,5 @@
-import pytest
 from starlette.status import HTTP_200_OK
 from starlette.testclient import TestClient
-
-pytestmark = pytest.mark.integration
 
 
 class TestTodo:

--- a/api/src/tests/integration/features/todo/test_todo_feature.py
+++ b/api/src/tests/integration/features/todo/test_todo_feature.py
@@ -8,8 +8,6 @@ from starlette.testclient import TestClient
 
 from data_providers.clients.client_interface import ClientInterface
 
-pytestmark = pytest.mark.integration
-
 
 class TestTodo:
     @pytest.fixture(autouse=True)

--- a/api/src/tests/integration/features/whoami/test_whoami_feature.py
+++ b/api/src/tests/integration/features/whoami/test_whoami_feature.py
@@ -1,12 +1,9 @@
-import pytest
 from starlette.status import HTTP_200_OK
 from starlette.testclient import TestClient
 
 from authentication.models import User
 from config import config
 from tests.integration.mock_authentication import get_mock_jwt_token
-
-pytestmark = pytest.mark.integration
 
 
 class TestWhoami:

--- a/api/src/tests/unit/features/todo/use_cases/test_add_todo.py
+++ b/api/src/tests/unit/features/todo/use_cases/test_add_todo.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from features.todo.repository.todo_repository_interface import TodoRepositoryInterface
 from features.todo.use_cases.add_todo import AddTodoRequest, add_todo_use_case

--- a/documentation/docs/about/running/03-starting-services.md
+++ b/documentation/docs/about/running/03-starting-services.md
@@ -3,7 +3,7 @@
 You can start running:
 
 ```shell
-docker-compose up
+docker compose up
 ```
 
 The web app will be served at [http://localhost](http://localhost)

--- a/documentation/docs/contribute/01-how-to-start-contributing.md
+++ b/documentation/docs/contribute/01-how-to-start-contributing.md
@@ -33,8 +33,8 @@ git checkout -b feature/my-new-feature
 5. Make the changes in the created branch.
 6. Add and run tests for your changes (we only take pull requests with passing tests).
 ```shell
-docker-compose run --rm api pytest
-docker-compose run --rm web yarn test
+docker compose run --rm api pytest
+docker compose run --rm web yarn test
 ```
 7. Add the changed files
 ```shell

--- a/documentation/docs/contribute/development-guide/03-testing.md
+++ b/documentation/docs/contribute/development-guide/03-testing.md
@@ -17,7 +17,7 @@ You will find unit tests under `src/tests/unit`.
 <TabItem value="using-docker" label="Using docker">
 
 ```shell
-docker-compose run --rm api pytest
+docker compose run --rm api pytest
 ```
 
 </TabItem>
@@ -50,7 +50,7 @@ These tests depends on mongodb and that it's running.
 <TabItem value="using-docker" label="Using docker">
 
 ```shell
-docker-compose run --rm web yarn test
+docker compose run --rm web yarn test
 ```
 
 </TabItem>

--- a/documentation/docs/contribute/development-guide/04-upgrading.md
+++ b/documentation/docs/contribute/development-guide/04-upgrading.md
@@ -7,7 +7,7 @@ Remember to restart!
 
 Any changes you make to these files will only come into effect after you restart the
 server. If you run the application using containers,
-you need to do `docker-compose build` and then `docker-compose up` to get the changes.
+you need to do `docker compose build` and then `docker compose up` to get the changes.
 
 :::
 

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.8.0/schema.json",
   "files": {
-    "ignore": ["documentation/*", "api/*", "web/src/api/generated"]
+    "ignore": [
+      "documentation/*",
+      "api/*",
+      "web/src/api/generated",
+      ".release-please-manifest.json"
+    ]
   },
   "javascript": {
     "formatter": {

--- a/web/generate-api-typescript-client-pre-commit.sh
+++ b/web/generate-api-typescript-client-pre-commit.sh
@@ -3,6 +3,8 @@ set -eo
 
 PATTERN="api/src/features/*"
 PATTERN+="|api/src/entities/*"
+PATTERN+="|api/src/common/*"
+PATTERN+="|api/src/authentication/*"
 
 CHANGED_API_FILES=()
 while read; do

--- a/web/src/api/generated/core/request.ts
+++ b/web/src/api/generated/core/request.ts
@@ -1,4 +1,4 @@
-/* generated using openapi-typescript-codegen -- do no edit */
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -145,10 +145,13 @@ export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Reso
 };
 
 export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
-    const token = await resolve(options, config.TOKEN);
-    const username = await resolve(options, config.USERNAME);
-    const password = await resolve(options, config.PASSWORD);
-    const additionalHeaders = await resolve(options, config.HEADERS);
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
+
     const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
 
     const headers = Object.entries({
@@ -172,7 +175,7 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
         headers['Authorization'] = `Basic ${credentials}`;
     }
 
-    if (options.body) {
+    if (options.body !== undefined) {
         if (options.mediaType) {
             headers['Content-Type'] = options.mediaType;
         } else if (isBlob(options.body)) {
@@ -212,6 +215,7 @@ export const sendRequest = async <T>(
         data: body ?? formData,
         method: options.method,
         withCredentials: config.WITH_CREDENTIALS,
+        withXSRFToken: config.CREDENTIALS === 'include' ? config.WITH_CREDENTIALS : false,
         cancelToken: source.token,
     };
 

--- a/web/src/api/generated/index.ts
+++ b/web/src/api/generated/index.ts
@@ -12,6 +12,7 @@ export type { AddTodoRequest } from './models/AddTodoRequest';
 export type { AddTodoResponse } from './models/AddTodoResponse';
 export type { DeleteTodoByIdResponse } from './models/DeleteTodoByIdResponse';
 export type { ErrorResponse } from './models/ErrorResponse';
+export type { GetTodoAllResponse } from './models/GetTodoAllResponse';
 export type { GetTodoByIdResponse } from './models/GetTodoByIdResponse';
 export type { UpdateTodoRequest } from './models/UpdateTodoRequest';
 export type { UpdateTodoResponse } from './models/UpdateTodoResponse';

--- a/web/src/api/generated/models/AddTodoRequest.ts
+++ b/web/src/api/generated/models/AddTodoRequest.ts
@@ -6,3 +6,4 @@
 export type AddTodoRequest = {
     title: string;
 };
+

--- a/web/src/api/generated/models/AddTodoResponse.ts
+++ b/web/src/api/generated/models/AddTodoResponse.ts
@@ -8,3 +8,4 @@ export type AddTodoResponse = {
     title: string;
     is_completed: boolean;
 };
+

--- a/web/src/api/generated/models/DeleteTodoByIdResponse.ts
+++ b/web/src/api/generated/models/DeleteTodoByIdResponse.ts
@@ -6,3 +6,4 @@
 export type DeleteTodoByIdResponse = {
     success: boolean;
 };
+

--- a/web/src/api/generated/models/ErrorResponse.ts
+++ b/web/src/api/generated/models/ErrorResponse.ts
@@ -10,3 +10,4 @@ export type ErrorResponse = {
     debug?: string;
     extra?: (Record<string, any> | null);
 };
+

--- a/web/src/api/generated/models/GetTodoAllResponse.ts
+++ b/web/src/api/generated/models/GetTodoAllResponse.ts
@@ -3,7 +3,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type UpdateTodoResponse = {
-    success: boolean;
+export type GetTodoAllResponse = {
+    id: string;
+    title: string;
+    is_completed: boolean;
 };
 

--- a/web/src/api/generated/models/GetTodoByIdResponse.ts
+++ b/web/src/api/generated/models/GetTodoByIdResponse.ts
@@ -8,3 +8,4 @@ export type GetTodoByIdResponse = {
     title: string;
     is_completed: boolean;
 };
+

--- a/web/src/api/generated/models/UpdateTodoRequest.ts
+++ b/web/src/api/generated/models/UpdateTodoRequest.ts
@@ -7,3 +7,4 @@ export type UpdateTodoRequest = {
     title?: string;
     is_completed: boolean;
 };
+

--- a/web/src/api/generated/models/User.ts
+++ b/web/src/api/generated/models/User.ts
@@ -12,3 +12,4 @@ export type User = {
     roles: Array<string>;
     scope: AccessLevel;
 };
+

--- a/web/src/api/generated/services/TodosService.ts
+++ b/web/src/api/generated/services/TodosService.ts
@@ -5,6 +5,7 @@
 import type { AddTodoRequest } from '../models/AddTodoRequest';
 import type { AddTodoResponse } from '../models/AddTodoResponse';
 import type { DeleteTodoByIdResponse } from '../models/DeleteTodoByIdResponse';
+import type { GetTodoAllResponse } from '../models/GetTodoAllResponse';
 import type { GetTodoByIdResponse } from '../models/GetTodoByIdResponse';
 import type { UpdateTodoRequest } from '../models/UpdateTodoRequest';
 import type { UpdateTodoResponse } from '../models/UpdateTodoResponse';
@@ -17,10 +18,10 @@ export class TodosService {
 
     /**
      * Get Todo All
-     * @returns any Successful Response
+     * @returns GetTodoAllResponse Successful Response
      * @throws ApiError
      */
-    public static getAll(): CancelablePromise<any> {
+    public static getAll(): CancelablePromise<Array<GetTodoAllResponse>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/todos',


### PR DESCRIPTION
## Why is this pull request needed?
The old setup didn't work particularly well/was buggy.

## What does this pull request change?
Markers are automatically added based on the parent test directory.
`pytest --unit` and `pytest` runs unit tests, while `pytest --integration` runs integration tests. Finally, `pytest --unit --integration` runs both. Furthermore, one can use markers to select the appropriate tests even quicker: e.g. `pytest -m integration`, which skips collecting all tests and just collects integration tests.

Also, pre-commit was failing on main, so I had to make some additional changes in order to make it run successfully. The state of this repo right now ...

## Issues related to this change:
None.