### PR TITLE
fix/404 on all react-router paths

### DIFF
--- a/web/nginx/environments/web.prod.conf
+++ b/web/nginx/environments/web.prod.conf
@@ -1,3 +1,5 @@
 root                /data/www/;
 include             /etc/nginx/config/general.conf;
 include             /etc/nginx/config/websocket.conf;
+index               index.html;
+try_files           $uri $uri/ /index.html;


### PR DESCRIPTION
Fixes a bug where routes defined only in the SPA (react-router etc.) returns 404.

nginx must return index.html for all files not found (assets, chunks, etc.)