### PR TITLE
ci: add staging environment

### DIFF
--- a/.github/workflows/deploy-to-radix.yaml
+++ b/.github/workflows/deploy-to-radix.yaml
@@ -7,11 +7,19 @@ on:
         default: "test"
         required: true
         type: string
+      image-tag:
+        description: "Which image tag to deploy."
+        required: true
+        type: string
   workflow_call: # Workflow is meant to be called from another workflow
     inputs:
       radix-environment:
         description: "Which radix environment to deploy into"
         default: "test"
+        required: true
+        type: string
+      image-tag:
+        description: "Which image tag to deploy."
         required: true
         type: string
 
@@ -62,3 +70,5 @@ jobs:
             --from-config
             --token-environment
             --follow
+            --image-tag-name api=${{ inputs.image-tag }}
+            --image-tag-name proxy=${{ inputs.image-tag }}

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -28,28 +28,28 @@ jobs:
     uses: ./.github/workflows/publish-image.yaml
     with:
       image-tags: latest
-      oauth-redirect-url: "https://proxy-template-fastapi-react-test.playground.radix.equinor.com/"
 # FIXME: DEMO CURRENTLY NOT DEPLOYED TO RADIX, comment back in to enable deployment to test environment
-#  deploy-test:
+#  deploy-dev:
 #    needs: publish-latest
 #    uses: ./.github/workflows/deploy-to-radix.yaml
 #    with:
-#      radix-environment: "test"
+#      image-tag: "latest"
+#      radix-environment: "dev"
 
   release-please:
     needs: tests
     uses: ./.github/workflows/create-release-pr.yaml
 
-  publish-production:
+  publish-staging:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/publish-image.yaml
     with:
-      image-tags: production,${{ needs.release-please.outputs.tag_name }}
-      oauth-redirect-url: "https://template-fastapi-react.app.playground.radix.equinor.com"
+      image-tags: ${{ needs.release-please.outputs.tag_name }}
 # FIXME: DEMO CURRENTLY NOT DEPLOYED TO RADIX, comment back in to enable deployment to production environment
-#  deploy-prod:
-#    needs: publish-production
+#  deploy-staging:
+#    needs: [release-please, publish-staging]
 #    uses: ./.github/workflows/deploy-to-radix.yaml
 #    with:
-#      radix-environment: "prod"
+#      image-tag: ${{ needs.release-please.outputs.tag_name }}
+#      radix-environment: "staging"

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -7,11 +7,6 @@ on:
         description: "Which tag to give the images. Supports multiple tags if comma separated, ie 'tag1,tag2'"
         required: true
         type: string
-      oauth-redirect-url:
-        description: "Redirect url for oauth. Should be the public url to access the web app"
-        default: "https://template-fastapi-react.app.playground.radix.equinor.com"
-        required: true
-        type: string
     secrets:
       CR_SECRET:
         description: "Secret to authenticate if using an other container registry than Github"
@@ -39,7 +34,6 @@ jobs:
           docker pull $NGINX_IMAGE
           printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./web/public/version.txt
           docker build \
-          --build-arg REDIRECT_URI=${{inputs.oauth-redirect-url}} \
           --build-arg AUTH_ENABLED=1 \
           --build-arg AUTH_SCOPE=api://4a761bec-628d-4c4b-860a-4903cbecc963/api \
           --build-arg CLIENT_ID=4a761bec-628d-4c4b-860a-4903cbecc963 \

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   environments:
     - name: prod
+    - name: staging
       build:
         from: main
-    - name: test
+    - name: dev
       build:
         from: main
   components:
@@ -23,15 +24,20 @@ spec:
           cpu: "4000m"
       environmentConfig:
         - environment: prod
-          imageTagName: production
+          imageTagName: latest
           horizontalScaling:
             minReplicas: 1
             maxReplicas: 4
-        - environment: test
+        - environment: staging
           imageTagName: latest
           horizontalScaling:
             minReplicas: 1
             maxReplicas: 2
+        - environment: dev
+          imageTagName: latest
+          horizontalScaling:
+            minReplicas: 1
+            maxReplicas: 1
       secrets:
         - SECRET_KEY
         - MONGODB_PASSWORD
@@ -58,11 +64,11 @@ spec:
       alwaysPullImageOnDeploy: true
       environmentConfig:
         - environment: prod
-          imageTagName: production
-        - environment: test
           imageTagName: latest
-      variables:
-        AUTH_ENABLED: "True"
+        - environment: staging
+          imageTagName: latest
+        - environment: dev
+          imageTagName: latest
       ports:
         - name: nginx
           port: 8080

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -33,7 +33,6 @@ USER 1000
 
 FROM node:22 AS base
 ARG AUTH_ENABLED=0
-ARG REDIRECT_URI=http://localhost/
 # Azure AD requires a scope.
 ARG AUTH_SCOPE=""
 ARG CLIENT_ID=""
@@ -45,7 +44,6 @@ ENV VITE_AUTH_TENANT=$TENANT_ID
 ENV VITE_TOKEN_ENDPOINT=https://login.microsoftonline.com/${VITE_AUTH_TENANT}/oauth2/v2.0/token
 ENV VITE_AUTH_ENDPOINT=https://login.microsoftonline.com/${VITE_AUTH_TENANT}/oauth2/v2.0/authorize
 ENV VITE_LOGOUT_ENDPOINT=https://login.microsoftonline.com/${VITE_AUTH_TENANT}/oauth2/logout
-ENV VITE_AUTH_REDIRECT_URI=$REDIRECT_URI
 
 WORKDIR /code
 COPY ./ ./

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -5,7 +5,7 @@ export const authConfig: TAuthConfig = {
   authorizationEndpoint: import.meta.env.VITE_AUTH_ENDPOINT || '',
   tokenEndpoint: import.meta.env.VITE_TOKEN_ENDPOINT || '',
   scope: import.meta.env.VITE_AUTH_SCOPE || '',
-  redirectUri: import.meta.env.VITE_AUTH_REDIRECT_URI || '',
+  redirectUri: window.origin,
   logoutEndpoint: import.meta.env.VITE_LOGOUT_ENDPOINT || '',
   autoLogin: false,
   preLogin: () =>


### PR DESCRIPTION
## Why is this pull request needed?

Currently we only have two environments: test (dev) and prod. Adding a third staging / QA environment will serve as a buffer between the two environments to make production more stable.

## What does this pull request change?

- Add staging environment to radix that will be published on release
  - Prod will be promoted to from staging manually in radix console
- Remove unnecessary AUTH_REDIRECT_URI environment variable

## Issues related to this change:
