### PR TITLE
fix: run tests from the src folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest-check
-        entry: sh -c "if [ -f api/.venv/bin/python ]; then var=api/.venv/bin/python; else var=api/.venv/Scripts/python; fi; $var -m pytest api/src/tests"
+        entry: sh -c "cd ./api/src/ && poetry run pytest ./tests/"
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Why is this pull request needed?

Run tests from the test folder so that test data can be be imported consistently

## What does this pull request change?

update pre-commit hook to run tests in the test folder

## Issues related to this change:
