### PR TITLE
fix: disable csp locally

### DIFF
--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -15,14 +15,13 @@ export default defineConfig({
     svgrPlugin(),
     csp({
       dev: {
-        run: true,
+        run: false,
       },
       policy: {
         'default-src': ["'self'"],
         'font-src': ["'self'", 'https://*.equinor.com'],
         'style-src': ["'self'", "'unsafe-inline'", 'https://*.equinor.com'],
-        'script-src-elem': ["'self'"],
-        'connect-src': ['self', 'https://*.microsoftonline.com', 'http:', ' https:', 'ws:', 'wss:', 'data:', 'blob:'],
+        'connect-src': ["'self'", 'https://*.microsoftonline.com', 'http:', ' https:'],
       },
       build: {
         sri: true,


### PR DESCRIPTION
## Why is this pull request needed?

Do not have to generate SRI locally. Conflicts with react reload script etc.

## What does this pull request change?

Disable SRI when running yarn start, only on yarn build

## Issues related to this change:
