### PR TITLE
chore(workflow): update upload artifact action to v4

### DIFF
--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -51,7 +51,7 @@ jobs:
 
       # Create changelog artifact
       - name: Upload changelog
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CHANGELOG
           path: CHANGELOG.md


### PR DESCRIPTION
## Why is this pull request needed?

v3 is deprecated

## What does this pull request change?

update version to v4

## Issues related to this change:
