### PR TITLE
chore: biome match installed package version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     rev: v0.4.0
     hooks:
       - id: biome-check
-        additional_dependencies: [ "@biomejs/biome@1.8.3" ]
+        additional_dependencies: [ "@biomejs/biome@1.9.4" ]
         args: ["--config-path", "web"]
 
 

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
     "ignore": [
       "build/*",


### PR DESCRIPTION
Biome schema can match installed package version + update version used in pre-commit

## Issues related to this change:
#275 