### PR TITLE
fix: avoid prop forwarding to dom using sc prefix

### DIFF
--- a/web/src/features/todos/todo-list/TodoItem.styled.tsx
+++ b/web/src/features/todos/todo-list/TodoItem.styled.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 
-export const StyledTodoItemTitle = styled(Typography)<{ isStruckThrough?: boolean }>`
-  text-decoration: ${(props) => (props.isStruckThrough ? 'line-through' : 'none')};
+export const StyledTodoItemTitle = styled(Typography)<{ $isStruckThrough?: boolean }>`
+  text-decoration: ${(props) => (props.$isStruckThrough ? 'line-through' : 'none')};
 `

--- a/web/src/features/todos/todo-list/TodoItem.tsx
+++ b/web/src/features/todos/todo-list/TodoItem.tsx
@@ -26,7 +26,7 @@ const TodoItem = ({ todo }: { todo: AddTodoResponse }) => {
     <Card>
       <Card.Header>
         <Card.HeaderTitle>
-          <StyledTodoItemTitle variant="h5" isStruckThrough={todo.is_completed}>
+          <StyledTodoItemTitle variant="h5" $isStruckThrough={todo.is_completed}>
             {todo.title}
           </StyledTodoItemTitle>
           <Typography variant="body_short">{statusOf(todo.is_completed)}</Typography>


### PR DESCRIPTION
## Why is this pull request needed?
Console error logging about styled-components props forwarding unknown props to DOM

## What does this pull request change?
Use styled-component prefix on sc specific props