### PR TITLE
ci: update pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,63 +4,76 @@ repos:
   - repo: local
     hooks:
       - id: generate-api-client
-        name: generate-api
+        name: "Generate: API TypeScript types"
         entry: ./web/generate-api-typescript-client-pre-commit.sh
         language: system
         pass_filenames: false
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: check-ast
-        language_version: python3.12
-      - id: check-merge-conflict
-      - id: check-case-conflict
-      - id: check-json
-      - id: check-toml
-      - id: check-yaml
-      - id: trailing-whitespace
-        exclude: ^web/src/api/generated/|^.*\.(lock)$
-      - id: end-of-file-fixer
-        exclude: ^web/src/api/generated/|^.*\.(lock)$
-      - id: mixed-line-ending
-        exclude: ^.*\.(lock)$
-      - id: detect-private-key
-        exclude: api/src/tests/integration/mock_authentication.py
-      - id: no-commit-to-branch
-        args: [--branch, main, --branch, master]
-        stages: [commit-msg]
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.4.0
     hooks:
       - id: conventional-pre-commit
+        name: "Validate: commit message follows conventional standards"
         stages: [commit-msg]
 
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+        name: "Validate: no merge conflict strings"
+      - id: no-commit-to-branch
+        name: "Validate: no commit to main"
+        args: [--branch, main, --branch, master]
+        stages: [commit-msg]
+      - id: check-ast
+        name: "Validate: parse .py files"
+        language_version: python3.12
+      - id: check-json
+        name: "Validate: parse .json files"
+      - id: check-toml
+        name: "Validate: parse .toml files"
+      - id: check-yaml
+        name: "Validate: parse .yaml files"
+      - id: check-case-conflict
+        name: "Validate: no case conflicting file names"
+      - id: trailing-whitespace
+        name: "Lint: remove trailing whitespaces"
+        exclude: ^web/src/api/generated/|^.*\.(lock)$
+      - id: end-of-file-fixer
+        name: "Lint: make files end with only newline"
+        exclude: ^web/src/api/generated/|^.*\.(lock)$
+      - id: mixed-line-ending
+        name: "Lint: ensure file ending is consistent"
+        exclude: ^.*\.(lock)$
+      - id: detect-private-key
+        name: "Validate: ensure no private keys are commited"
+        exclude: api/src/tests/integration/mock_authentication.py
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.6.3"
+    rev: "v0.9.7"
     hooks:
       - id: ruff
-        name: Python lint
+        name: "Lint: ruff (python)"
         files: ^api/.*\.py$
         args: ["--fix"]
 
       - id: ruff-format
-        name: Python format
+        name: "Lint: ruff-format (python)"
         files: ^api/.*\.py$
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v0.4.0
+    rev: v0.6.1
     hooks:
       - id: biome-check
+        name: "Lint: biome (ts/js)"
         additional_dependencies: ["@biomejs/biome@1.9.4"]
         args: ["--config-path", "web"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.15.0
     hooks:
       - id: mypy
-        name: Type checking
+        name: "Lint: python type checking (mypy)"
         args: [--config-file=api/pyproject.toml]
         exclude: tests/
         additional_dependencies:
@@ -78,17 +91,17 @@ repos:
   - repo: local
     hooks:
       - id: pytest
-        name: pytest-check
+        name: "Tests: python unit tests"
         entry: sh -c "cd ./api/src/ && poetry run pytest ./tests/"
         language: system
         pass_filenames: false
         always_run: true
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.4.1
     hooks:
       - id: codespell
-        name: codespell
+        name: "Lint: spelling"
         description: Checks for common misspellings in text files.
         entry: codespell --toml=api/pyproject.toml
         exclude: documentation/docs/changelog/changelog.md

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -15,7 +15,7 @@ class Config(BaseSettings):
 
     # Database
     MONGODB_USERNAME: str = "dummy"
-    MONGODB_PASSWORD: str = "dummy"
+    MONGODB_PASSWORD: str = "dummy"  # noqa: S105
     MONGODB_HOSTNAME: str = "db"
     MONGODB_DATABASE: str = "test"
     MONGODB_PORT: int = 27017

--- a/documentation/docs/contribute/development-guide/coding/extending-the-web/index.md
+++ b/documentation/docs/contribute/development-guide/coding/extending-the-web/index.md
@@ -26,7 +26,7 @@ The web has a feature-based folder structure.
 - `api` contains the auto-generated API client
 - `common` contains shared code like generic components
 - `features` contains features e.g. todo-list
-- `hooks` contains re-usable hooks
+- `hooks` contains reusable hooks
 - `pages` contains entrypoints (pages that are used by the router)
 
 ## Application tree
@@ -63,8 +63,8 @@ flowchart
 
 External dependencies:
 
-* The app is using [react-oauth2-code-pkce](https://www.npmjs.com/package/react-oauth2-code-pkce) for Oauth2 authentication.
-* The app is using [react-router-dom](https://www.npmjs.com/package/react-router-dom) for routing.
+- The app is using [react-oauth2-code-pkce](https://www.npmjs.com/package/react-oauth2-code-pkce) for Oauth2 authentication.
+- The app is using [react-router-dom](https://www.npmjs.com/package/react-router-dom) for routing.
 
 ## Configuration
 

--- a/web/generate-api-typescript-client-pre-commit.sh
+++ b/web/generate-api-typescript-client-pre-commit.sh
@@ -7,45 +7,43 @@ PATTERN+="|api/src/common/*"
 PATTERN+="|api/src/authentication/*"
 
 CHANGED_API_FILES=()
-while read; do
+while read -r; do
   CHANGED_API_FILES+=("$REPLY")
-done < <(echo "$(git diff --name-only --cached --diff-filter=ACMR)" | grep -E $PATTERN)
+done < <(git diff --name-only --cached --diff-filter=ACMR | grep -E "$PATTERN")
 
 if [ ${#CHANGED_API_FILES[@]} -eq 0 ]; then
-    echo "No changes in API relevant files. No need to generate API."
-else
-    echo "Changes detected in API relevant files. Generating API ..."
-    # This requires the API to be running on localhost port 5000
-    # Define the URL of the OpenAPI specification
-    OPENAPI_URL="http://0.0.0.0:5000/openapi.json"
-
-    # Use curl to fetch the OpenAPI specification and store it in a temporary file
-    TEMP_FILE=$(mktemp)
-    curl -s "$OPENAPI_URL" > "$TEMP_FILE"
-
-    # Check if the curl command was successful
-    if [ $? -ne 0 ]; then
-      echo "Failed to fetch the OpenAPI specification."
-      rm "$TEMP_FILE"
-      exit 1
-    fi
-
-    # Use grep to extract the name from the OpenAPI specification
-    NAME=$(grep -o -s '"title": *"[^"]*"' "$TEMP_FILE" | head -1 | awk -F '"' '{print $4}')
-
-    # Check if the name is empty or null
-    if [ -z "$NAME" ]; then
-      echo "Name of API not found in the OpenAPI specification."
-      exit 1
-    elif [ "$NAME" != "Template FastAPI React" ]; then
-      echo "The openapi specification found at localhost:5000 ('$NAME') does not seem to belong to 'Template FastAPI React'"
-      exit 1
-    else
-      cd web
-      yarn openapi -i http://localhost:5000/openapi.json -o "$PWD/src/api/generated"
-      echo "API Client successfully generated"
-    fi
-
-    # Clean up the temporary file
-    rm "$TEMP_FILE"
+  echo "No changes in API relevant files. No need to generate API."
+  exit 0
 fi
+
+echo "Changes detected in API relevant files. Generating API ..."
+# This requires the API to be running on localhost port 5000
+# Define the URL of the OpenAPI specification
+OPENAPI_URL="http://0.0.0.0:5000/openapi.json"
+
+# Use curl to fetch the OpenAPI specification and store it in a temporary file
+TEMP_FILE=$(mktemp)
+if ! curl -s "$OPENAPI_URL" >"$TEMP_FILE"; then
+  echo "Failed to fetch the OpenAPI specification."
+  rm "$TEMP_FILE"
+  exit 1
+fi
+
+# Use grep to extract the name from the OpenAPI specification
+NAME=$(grep -o -s '"title": *"[^"]*"' "$TEMP_FILE" | head -1 | awk -F '"' '{print $4}')
+
+# Check if the name is empty or null
+if [ -z "$NAME" ]; then
+  echo "Name of API not found in the OpenAPI specification."
+  exit 1
+elif [ "$NAME" != "Template FastAPI React" ]; then
+  echo "The openapi specification found at localhost:5000 ('$NAME') does not seem to belong to 'Template FastAPI React'"
+  exit 1
+else
+  cd web
+  yarn openapi -i http://localhost:5000/openapi.json -o "$PWD/src/api/generated"
+  echo "API Client successfully generated"
+fi
+
+# Clean up the temporary file
+rm "$TEMP_FILE"

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "start": "vite",
     "build": "tsc && vite build",
     "serve": "vite preview",
-    "generate": "openapi -i http://localhost:5001/openapi.json -o './src/api/generated' -c axios",
+    "generate": "openapi -i http://localhost:5000/openapi.json -o './src/api/generated' -c axios",
     "test": "vitest",
     "lint": "biome check --write --no-errors-on-unmatched"
   },


### PR DESCRIPTION
## Why is this pull request needed?
Some of the hooks in the pre-commit was running old versions.

## What does this pull request change?
Updates versions.
Additionally I changed the port in `yarn generate` command as it was pointing to 5001.
Furthermore, bashls had some suggestions to improving the script itself, so I applied those:
- "[SC2162] Read without -r will mangle backslashes"
- "[SC2086] Double quote to prevent globbing and word splitting"
- "[SC2005] Useless echo? Instead of `echo $(cmd)` just use `cmd`"
- "[SC2181] Check exit code directly with e.g. `if ! mycmd;`, not indirectly with $?."
- Added early exit if no changes are detected instead of using else.

Also had to do some fixes due to updated hooks detecting new errors.

## Issues related to this change:
Closes #276
