### PR TITLE
ci: change how codeql is run

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,8 +3,13 @@
 name: "Run CodeQL security analysis"
 
 on:
-  workflow_dispatch:
-  workflow_call:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # uncomment this to run codeql weekly at 23:59 at Sundays
+  # schedule:
+  #   - cron: "59 23 * * 0"
 
 jobs:
   analyze:

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -4,8 +4,5 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  codeql:
-    uses: ./.github/workflows/codeql.yaml
-
   tests:
     uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -8,9 +8,6 @@ on:
       - "CHANGELOG.md"
 
 jobs:
-  codeql:
-    uses: ./.github/workflows/codeql.yaml
-
   tests:
     uses: ./.github/workflows/tests.yaml
 

--- a/.github/workflows/on-weekly.yaml
+++ b/.github/workflows/on-weekly.yaml
@@ -1,8 +1,0 @@
-name: "On weekly"
-on:
-  schedule:
-    - cron: "34 19 * * 0"
-
-jobs:
-  codeql:
-    uses: ./.github/workflows/codeql.yaml


### PR DESCRIPTION
## Why is this pull request needed?
Codeql does not function properly.

## What does this pull request change?
Changes how codeql is called in actions. 
It needs a specific on.push hook, making it difficult to integrate into our workflows (due to how they are triggered). Therefore it is now run seperately on pushes and on pull requests to main.

## Issues related to this change:
None
