### PR TITLE
CI: Disable web-tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,6 +54,7 @@ jobs:
 
   web-tests:
     runs-on: ubuntu-latest
+    if: ${{ false }} # disable for now as they do not currently work
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Why is this pull request needed?

It seems like the `web-tests` job currently does not work. To avoid getting a failed test, this PR disables it until it someday maybe is fixed

## What does this pull request change?

Simply disables the entire job instead of only the step performing the tests

See the following workflow run to see that the job is skipped: https://github.com/equinor/template-fastapi-react/actions/runs/15558965865?pr=323

## Issues related to this change:
