### PR TITLE
fix: Propagate SIGINT signal

### DIFF
--- a/api/src/init.sh
+++ b/api/src/init.sh
@@ -2,7 +2,7 @@
 set -eu
 
 if [ "$1" = 'api' ]; then
-  python3 ./app.py run
+  exec python3 ./app.py run
 else
   exec "$@"
 fi


### PR DESCRIPTION
## Why is this pull request needed?

`SIGINT` signal from docker is forwarded to `init.sh`, but not to the python process. This means that when one e.g tries to gracefully stop the `api` service, the signal will not propagate to the python process, and after 10 seconds the `SIGKILL` signal will be sent instead.

## What does this pull request change?

using `exec` to run the python script will correctly propagate the `SIGINT` signal and stop the service almost immediately.

You can test this out yourselves by doing the following:
* Without the changes in this PR (e.g main branch) Try to run `docker compose up --build`. Then try to ctr+c to stop the containers. You will see that all services but the `api` service stops pretty fast. The `api` service stops after 10 seconds.

* With the changes in this branch, try to do the same. See that all services now stop pretty fast

## Issues related to this change:
Not that i know of