### PR TITLE
ci: Add `documentation` directory to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/web"
+    directories:
+      - "/web"
+      - "/documentation"
     schedule:
       interval: "monthly" # when template is used, recommended interval is "weekly"
     groups:


### PR DESCRIPTION
## Why is this pull request needed?
To cover `documentation` folder for dependabot

## What does this pull request change?
Dependabot will now update dependencies in `documentation`

