### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/api/src/authentication/authentication.py
+++ b/api/src/authentication/authentication.py
@@ -24,7 +24,7 @@ def get_JWK_client() -> jwt.PyJWKClient:
         oid_conf = oid_conf_response.json()
         return jwt.PyJWKClient(oid_conf["jwks_uri"])
     except Exception as error:
-        logger.error(f"Failed to fetch OpenId Connect configuration for '{config.OAUTH_WELL_KNOWN}': {error}")
+        logger.error(f"Failed to fetch OpenId Connect configuration: {error}")
         raise UnauthorizedException
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/template-fastapi-react/security/code-scanning/2](https://github.com/equinor/template-fastapi-react/security/code-scanning/2)

To fix this problem, we should avoid directly logging the value of `config.OAUTH_WELL_KNOWN`. Instead, we can log a general error message without including the potentially sensitive configuration value. This ensures attackers cannot retrieve configuration details from log files, and we maintain useful error logging for debugging.

Hence, in `get_JWK_client` on line 27, we should change:

```python
logger.error(f"Failed to fetch OpenId Connect configuration for '{config.OAUTH_WELL_KNOWN}': {error}")
```

to something like:

```python
logger.error(f"Failed to fetch OpenId Connect configuration: {error}")
```

No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
