### PR TITLE
chore: bump tool versions

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
-python = "3.14.3"
-node = { version = "24.13.1", postinstall = "mise tasks run tools:yarn" }
+python = "3.14.4"
+node = { version = "24.14.1", postinstall = "mise tasks run tools:yarn" }
 pre-commit = "4.5.1"
-uv = "0.10.8"
+uv = "0.11.6"
 
 [task_config]
 includes = [".mise/tasks/*.toml"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # First, build the application in the `/app` directory
-FROM python:3.14.3-slim-trixie AS base
+FROM python:3.14.4-slim-trixie AS base
 ENV XDG_CACHE_HOME=/var/lib
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 
@@ -11,7 +11,7 @@ EXPOSE 5000
 ENV PYTHONPATH=/app/src
 
 FROM base AS dependencies
-COPY --from=docker.io/astral/uv:0.10.7 /uv /uvx /usr/local/bin/
+COPY --from=docker.io/astral/uv:0.11.6 /uv /uvx /usr/local/bin/
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 


### PR DESCRIPTION
## Summary

Bump tool versions to latest in mise config and API Dockerfile.

## Changes

| Tool | Old | New | Location |
|---|---|---|---|
| Python | 3.14.3 | 3.14.4 | `.mise/config.toml`, `api/Dockerfile` |
| Node | 24.13.1 | 24.14.1 | `.mise/config.toml` |
| uv | 0.10.8 | 0.11.6 | `.mise/config.toml` |
| uv (Docker) | 0.10.7 | 0.11.6 | `api/Dockerfile` |