### PR TITLE
chore: isolate @hey-api/openapi-ts into its own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,14 @@ updates:
       interval: "monthly" # when template is used, recommended interval is "weekly"
     groups:
       web:
+        exclude-patterns:
+          - "@hey-api/openapi-ts"
         update-types:
           - "minor"
           - "patch"
+      openapi-ts:
+        patterns:
+          - "@hey-api/openapi-ts"
 
   - package-ecosystem: "docker"
     directories:


### PR DESCRIPTION
Separates `@hey-api/openapi-ts` from the `web` dependabot group into its own group.

This package frequently ships breaking changes (e.g. 15 breaking changes in 0.97.0), which requires regenerating the API client. Isolating it makes it easier to review and handle those updates independently from routine dependency bumps.