### PR TITLE
chore: migrate pre-commit to prek with workspace mode

### DIFF
--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -30,10 +30,14 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         timeout-minutes: 5
 
-      - name: "Run: pre-commit"
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: --all-files
+      - name: "Setup: install API dependencies"
+        run: mise run install-dependencies:api
+
+      - name: "Setup: install Web dependencies"
+        run: mise run install-dependencies:web
+
+      - name: "Run: prek"
+        run: mise exec -- prek run --all-files --show-diff-on-failure
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -17,6 +17,11 @@ env:
   REGISTRY_USER: $GITHUB_ACTOR
   API_IMAGE: ghcr.io/equinor/template-fastapi-react/api
   WEB_IMAGE: ghcr.io/equinor/template-fastapi-react/web
+  # mise runs the node postinstall hook (corepack install) in a pseudo-TTY.
+  # Without this, corepack shows an interactive download prompt and blocks the
+  # "Setup: Runtimes" step until it times out. Set at workflow scope so it is in
+  # the process environment that mise install and the hook inherit.
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
 
 jobs:
   pre-commit:

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -2,7 +2,7 @@
 python = "3.14.4"
 # Keep in sync with the `dhi.io/node:<version>-debian13-dev` tag in web/Dockerfile.
 node = { version = "24.13.1", postinstall = "mise tasks run tools:yarn" }
-pre-commit = "4.5.1"
+prek = "0.3.11"
 uv = "0.11.6"
 shellcheck = "0.10.0"
 

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -7,6 +7,11 @@ uv = "0.11.6"
 shellcheck = "0.10.0"
 
 [env]
+# Disable corepack's interactive "about to download" prompt. mise runs tasks
+# (including the node postinstall hook) in a pseudo-TTY, so corepack would
+# otherwise block forever waiting for confirmation in non-interactive CI.
+COREPACK_ENABLE_DOWNLOAD_PROMPT = "0"
+
 # Name for resource group, Azure resources, app registrations, and Docker image tags.
 # Lowercase alphanumeric and hyphens only. Change once when adopting this template.
 APPLICATION_NAME = "<REPLACE_ME>"

--- a/.mise/tasks/tools.toml
+++ b/.mise/tasks/tools.toml
@@ -1,4 +1,11 @@
 ["tools:yarn"]
 hide = true
 dir = "{{config_root}}/web"
-run = ["corepack enable", "corepack install"]
+# Set the corepack prompt flag on the command itself (mise's postinstall hook
+# does not reliably forward outer env into the spawned process) and redirect
+# stdin from /dev/null so corepack can never block on an interactive prompt and
+# stall the CI runtime-setup step until it times out.
+run = [
+  "corepack enable </dev/null",
+  "COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack install </dev/null",
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,17 @@
 default_stages: [pre-commit]
 default_install_hook_types: [pre-commit, commit-msg]
+
+# Workspace-mode root config (run via `prek`).
+# Project-specific hooks live in `api/.pre-commit-config.yaml` and
+# `web/.pre-commit-config.yaml`. See https://prek.j178.dev/workspace/.
+
 repos:
   - repo: local
     hooks:
       - id: generate-openapi-spec
-        name: Generate OpenAPI spec
+        name: "Build: generate OpenAPI spec"
         entry: mise run generate:openapi-spec
-        language: python
+        language: system
         files: |
           (?x)(
             ^api/src/app/(features|common|authentication|entities)/.*\.py$
@@ -16,7 +21,7 @@ repos:
         pass_filenames: false
 
       - id: generate-api-client-from-spec
-        name: Generate the client for our api
+        name: "Build: generate API client from spec"
         entry: mise run generate:api-client-from-spec
         language: system
         files: ^api/.openapi.json$
@@ -65,30 +70,6 @@ repos:
       - id: detect-private-key
         name: "Check: no private keys are commited"
         exclude: api/tests/integration/mock_authentication.py
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.14"
-    hooks:
-      - id: ruff-check
-        name: "Lint : ruff (python)"
-        files: ^api/.*\.py$
-        args: ["--fix"]
-
-      - id: ruff-format
-        name: "Lint : ruff-format (python)"
-        files: ^api/.*\.py$
-
-  - repo: https://github.com/biomejs/pre-commit
-    rev: v2.4.15
-    hooks:
-      - id: biome-check
-        name: "Lint : biome (ts/js)"
-        additional_dependencies: ["@biomejs/biome@2.4.15"]
-        exclude: |
-          (?x)(
-            ^web/\.pnp\.cjs$
-            |^web/\.pnp\.loader\.mjs$
-          )
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -66,7 +66,7 @@ See [resources](#resources) section for overview of all resources used by the ap
 * [React](https://react.dev/)
 * [Oauth2](https://oauth.net/2/)
 * [Python](https://www.python.org/)
-* [Pre-commit](https://pre-commit.com/)
+* [Pre-commit (via prek)](https://prek.j178.dev/)
 * [Git](https://git-scm.com/)
 
 </details>

--- a/api/.pre-commit-config.yaml
+++ b/api/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Project config for the API. Discovered automatically by `prek` workspace mode.
+# Hooks here run with this directory as their working directory and only
+# receive files inside `api/`. The ruff version is pinned in `pyproject.toml`
+# under `[dependency-groups] dev`.
+
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: "Lint : ruff (python)"
+        entry: uv run ruff check --fix
+        language: system
+        types_or: [python, pyi]
+
+      - id: ruff-format
+        name: "Lint : ruff-format (python)"
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -23,7 +23,21 @@ dev = [
   "mongomock>=4.1.2",
   "mypy>=2.1.0",
   "pytest>=8.3.0",
+  "ruff>=0.15.12",
   "types-cachetools>=7.0.0.20260518",
+]
+
+[tool.uv]
+# opentelemetry-sdk 1.39 removed `LogData` from `opentelemetry.sdk._logs`,
+# which breaks azure-monitor-opentelemetry-exporter (still on the old API
+# as of 1.0.0b45). Override the transitive resolution to keep us on the
+# last working SDK line until the exporter migrates to LogRecord. Pinning
+# in `dependencies` doesn't work — the instrumentation packages declare
+# matching `semantic-conventions` versions that drag the SDK back up.
+override-dependencies = [
+  "opentelemetry-sdk<1.39",
+  "opentelemetry-api<1.39",
+  "opentelemetry-semantic-conventions<0.60b0",
 ]
 
 [build-system]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -27,19 +27,6 @@ dev = [
   "types-cachetools>=7.0.0.20260518",
 ]
 
-[tool.uv]
-# opentelemetry-sdk 1.39 removed `LogData` from `opentelemetry.sdk._logs`,
-# which breaks azure-monitor-opentelemetry-exporter (still on the old API
-# as of 1.0.0b45). Override the transitive resolution to keep us on the
-# last working SDK line until the exporter migrates to LogRecord. Pinning
-# in `dependencies` doesn't work — the instrumentation packages declare
-# matching `semantic-conventions` versions that drag the SDK back up.
-override-dependencies = [
-  "opentelemetry-sdk<1.39",
-  "opentelemetry-api<1.39",
-  "opentelemetry-semantic-conventions<0.60b0",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -6,13 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[manifest]
-overrides = [
-    { name = "opentelemetry-api", specifier = "<1.39" },
-    { name = "opentelemetry-sdk", specifier = "<1.39" },
-    { name = "opentelemetry-semantic-conventions", specifier = "<0.60b0" },
-]
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -800,15 +793,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242, upload-time = "2025-10-16T08:35:50.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947, upload-time = "2025-10-16T08:35:30.23Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
 ]
 
 [[package]]
@@ -1008,29 +1001,29 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/cb/f0eee1445161faf4c9af3ba7b848cc22a50a3d3e2515051ad8628c35ff80/opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe", size = 171942, upload-time = "2025-10-16T08:36:02.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/2e/e93777a95d7d9c40d270a371392b6d6f1ff170c2a3cb32d6176741b5b723/opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b", size = 132349, upload-time = "2025-10-16T08:35:46.995Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.59b0"
+version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bc/8b9ad3802cd8ac6583a4eb7de7e5d7db004e89cb7efe7008f9c8a537ee75/opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0", size = 129861, upload-time = "2025-10-16T08:36:03.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/7d/c88d7b15ba8fe5c6b8f93be50fc11795e9fc05386c44afaf6b76fe191f9b/opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed", size = 207954, upload-time = "2025-10-16T08:35:48.054Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
 ]
 
 [[package]]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -6,6 +6,13 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[manifest]
+overrides = [
+    { name = "opentelemetry-api", specifier = "<1.39" },
+    { name = "opentelemetry-sdk", specifier = "<1.39" },
+    { name = "opentelemetry-semantic-conventions", specifier = "<0.60b0" },
+]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -59,6 +66,7 @@ dev = [
     { name = "mongomock" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "ruff" },
     { name = "types-cachetools" },
 ]
 
@@ -82,6 +90,7 @@ dev = [
     { name = "mongomock", specifier = ">=4.1.2" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=8.3.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260518" },
 ]
 
@@ -791,15 +800,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.40.0"
+version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242, upload-time = "2025-10-16T08:35:50.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947, upload-time = "2025-10-16T08:35:30.23Z" },
 ]
 
 [[package]]
@@ -999,29 +1008,29 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.40.0"
+version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/cb/f0eee1445161faf4c9af3ba7b848cc22a50a3d3e2515051ad8628c35ff80/opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe", size = 171942, upload-time = "2025-10-16T08:36:02.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/e93777a95d7d9c40d270a371392b6d6f1ff170c2a3cb32d6176741b5b723/opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b", size = 132349, upload-time = "2025-10-16T08:35:46.995Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.61b0"
+version = "0.59b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/bc/8b9ad3802cd8ac6583a4eb7de7e5d7db004e89cb7efe7008f9c8a537ee75/opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0", size = 129861, upload-time = "2025-10-16T08:36:03.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/c88d7b15ba8fe5c6b8f93be50fc11795e9fc05386c44afaf6b76fe191f9b/opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed", size = 207954, upload-time = "2025-10-16T08:35:48.054Z" },
 ]
 
 [[package]]
@@ -1393,6 +1402,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/d3/18210222b37e87e36357f7b300b7d98c6dd62b133771e71ae27acba83a4f/rignore-0.7.6-cp314-cp314t-win32.whl", hash = "sha256:c1d8f117f7da0a4a96a8daef3da75bc090e3792d30b8b12cfadc240c631353f9", size = 647033, upload-time = "2025-11-05T21:42:00.095Z" },
     { url = "https://files.pythonhosted.org/packages/3e/87/033eebfbee3ec7d92b3bb1717d8f68c88e6fc7de54537040f3b3a405726f/rignore-0.7.6-cp314-cp314t-win_amd64.whl", hash = "sha256:ca36e59408bec81de75d307c568c2d0d410fb880b1769be43611472c61e85c96", size = 725647, upload-time = "2025-11-05T21:41:44.449Z" },
     { url = "https://files.pythonhosted.org/packages/79/62/b88e5879512c55b8ee979c666ee6902adc4ed05007226de266410ae27965/rignore-0.7.6-cp314-cp314t-win_arm64.whl", hash = "sha256:b83adabeb3e8cf662cabe1931b83e165b88c526fa6af6b3aa90429686e474896", size = 656035, upload-time = "2025-11-05T21:41:31.13Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
     "includes": ["web/**", "!web/build", "!web/src/api/generated"]
   },

--- a/docs/docs/contribute/development-guide/01-setup.md
+++ b/docs/docs/contribute/development-guide/01-setup.md
@@ -8,29 +8,29 @@ To work with the template monorepo you'll need to install [these tools](../../ab
 
 When contributing to this project, pre-commits are necessary, as they run certain tests, sanitisers, and formatters.
 
-The project provides a `.pre-commit-config.yaml` file that is used to setup git _pre-commit hooks_.
+We use [`prek`](https://prek.j178.dev/) — a faster, drop-in compatible alternative to [`pre-commit`](https://pre-commit.com/) — to run hooks. Hooks are configured in [`.pre-commit-config.yaml`](https://github.com/equinor/template-fastapi-react/blob/main/.pre-commit-config.yaml) at the repository root, with project-specific hooks in `api/.pre-commit-config.yaml` and `web/.pre-commit-config.yaml` (see [prek workspace mode](https://prek.j178.dev/workspace/)).
 
-On commit locally, code is automatically formatted and checked for security vulnerabilities using pre-commit git hooks.
+On commit locally, code is automatically formatted and checked for security vulnerabilities using these hooks.
 
 ### Installation
 
-To initialize pre-commit in your local repository, run
+Install `prek` via [`mise`](https://mise.jdx.dev/) (recommended), `uv`, or `pip`, and then run:
 
 ```shell
-pre-commit install
+prek install
 ```
 
-This tells pre-commit to run for this repository on every commit.
+This tells `prek` to run for this repository on every commit.
 
 ### Usage
 
-Pre-commit will run on every commit, but can also be run manually on all files:
+Hooks run on every commit, but can also be triggered manually on all files:
 
 ```shell
-pre-commit run --all-files
+prek run --all-files
 ```
 
-Pre-commit tests can be skipped on commits with `git commit --no-verify`.
+Hooks can be skipped on commits with `git commit --no-verify`.
 
 !!! caution "Caution"
     If you have to skip the pre-commit tests, you're probably doing something you're not supposed to, and whoever commits after you might have to fix your "mistakes". Consider updating the pre-commit hooks if your code is non-compliant.

--- a/docs/docs/contribute/development-guide/01-setup.md
+++ b/docs/docs/contribute/development-guide/01-setup.md
@@ -33,7 +33,7 @@ prek run --all-files
 Hooks can be skipped on commits with `git commit --no-verify`.
 
 !!! caution "Caution"
-    If you have to skip the pre-commit tests, you're probably doing something you're not supposed to, and whoever commits after you might have to fix your "mistakes". Consider updating the pre-commit hooks if your code is non-compliant.
+    If you have to skip the hooks, you're probably doing something you're not supposed to, and whoever commits after you might have to fix your "mistakes". Consider updating the hooks if your code is non-compliant.
 
 ### Hooks
 <details>

--- a/web/.pre-commit-config.yaml
+++ b/web/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Project config for the Web app. Discovered automatically by `prek` workspace
+# mode. Hooks here run with this directory as their working directory and only
+# receive files inside `web/`. The @biomejs/biome version is pinned in
+# `package.json` under `devDependencies`.
+
+repos:
+  - repo: local
+    hooks:
+      - id: biome-check
+        name: "Lint : biome (ts/js)"
+        entry: yarn biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off
+        language: system
+        types_or: [javascript, jsx, ts, tsx, json, css]


### PR DESCRIPTION
## Summary

Replaces the `pre-commit` framework with [`prek`](https://prek.j178.dev/) — a faster, drop-in compatible Rust reimplementation — and adopts prek's [workspace mode](https://prek.j178.dev/workspace/) to split the configuration into one config per project.

## Why

- **Version drift**: ruff and biome were previously installed twice — once via the `astral-sh/ruff-pre-commit` / `biomejs/pre-commit` hook repos at one version, and again as dev dependencies in `api/pyproject.toml` / `web/package.json` at another version. Hooks now invoke the project-pinned binaries (`uv run ruff`, `yarn biome`), so the version in the lockfile is the version that runs.
- **Speed**: prek runs hooks in parallel where possible, has no Python bootstrap, and shares language toolchains across hooks.
- **Monorepo ergonomics**: with workspace mode, project-specific tooling lives next to the project it covers.

## Layout

| File | Scope |
|------|-------|
| `.pre-commit-config.yaml` | Cross-cutting checks: commit message format, file parsers, whitespace/EOL hygiene, OpenAPI spec + API client build hooks. |
| `api/.pre-commit-config.yaml` | `ruff check --fix` + `ruff format`, run via `uv run` from `api/`. |
| `web/.pre-commit-config.yaml` | `biome check --write`, run via `yarn biome` from `web/`. |

prek discovers all three configs automatically and runs hooks from the deepest project up — `api` and `web` first, then root.

## Other changes

- [.mise/config.toml](.mise/config.toml): replace `pre-commit = "4.5.1"` with `prek = "0.3.11"`.
- [api/pyproject.toml](api/pyproject.toml): add `ruff>=0.15.12` to the `dev` group so the pinned version drives both the editor and the hook.
- [biome.json](biome.json): enable `vcs.useIgnoreFile` so biome respects `.gitignore` (avoids linting the yarn-generated `.pnp.cjs` / `.pnp.loader.mjs`).
- [.github/workflows/linting-and-checks.yaml](.github/workflows/linting-and-checks.yaml): install api/web dependencies before running `prek run --all-files`, since the ruff and biome hooks shell out to `uv` / `yarn`.
- [docs/docs/contribute/development-guide/01-setup.md](docs/docs/contribute/development-guide/01-setup.md), [RUNBOOK.md](RUNBOOK.md): updated user-facing references to point at prek.

## Validation

`prek run --all-files` and `prek run --files <…>` were exercised against representative files from each project to confirm scoping is correct:

| Edited file | Hooks that run | Hooks that skip |
|---|---|---|
| `api/src/app/features/.../*.py` | ruff, ruff-format, generate-openapi-spec, root checks | biome, generate-api-client-from-spec |
| `api/tests/conftest.py` | ruff, ruff-format, root .py parser | generate-openapi-spec (outside trigger pattern) |
| `web/src/App.tsx` | biome, root whitespace/EOL | ruff, openapi hooks |
| `web/package.json` | biome, check-json, whitespace | ruff, openapi hooks |
| `api/.openapi.json` | generate-api-client-from-spec, check-json | ruff, generate-openapi-spec |
| `README.md` | only root whitespace/EOL/line-ending hooks | everything else |

## Migration for contributors

Install `prek` (any of: `mise install`, `uv tool install prek`, `pip install prek`, `brew install prek`) and run `prek install` once to register the git hooks. The project's `.pre-commit-config.yaml` files work unchanged with the legacy `pre-commit` CLI as well, so no flag day required.
