### PR TITLE
ci: replace deprecated `app-id` input for `create-github-app-token`

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,11 +14,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate token
-        id: generate-token
+      - name: Create token
+        id: create-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: release-please
@@ -27,7 +27,7 @@ jobs:
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.create-token.outputs.token }}
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}


### PR DESCRIPTION
<img width="623" height="71" alt="Screenshot 2026-05-15 at 10 59 07" src="https://github.com/user-attachments/assets/28289abc-3975-47ae-8e27-6fec5caae16a" />
