### PR TITLE
fix: user hashing a type instead of user id in api authentication

### DIFF
--- a/api/src/app/authentication/models.py
+++ b/api/src/app/authentication/models.py
@@ -42,7 +42,7 @@ class User(BaseModel):
     scope: AccessLevel = AccessLevel.WRITE
 
     def __hash__(self) -> int:
-        return hash(type(self.user_id))
+        return hash(self.user_id)
 
 
 class ACLDict(TypedDict):


### PR DESCRIPTION
## Why is this pull request needed?
Small issue we found where user hash is hashed from the type of user id, rather than the user id directly. This makes each user have the same hash in the same process.

## What does this pull request change?
Hash using `user_id`
