### PR TITLE
chore: add Dependabot cooldown and enforce locked installs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       - "/web"
     schedule:
       interval: "monthly" # when template is used, recommended interval is "weekly"
+    cooldown:
+      default-days: 7
     groups:
       web:
         exclude-patterns:
@@ -30,6 +32,8 @@ updates:
       - dhi-io
     schedule:
       interval: "monthly" # when template is used, recommended interval is "weekly"
+    cooldown:
+      default-days: 7
     groups:
       dockerfile:
         update-types:
@@ -42,6 +46,8 @@ updates:
       - "/api"
     schedule:
       interval: "monthly" # when template is used, recommended interval is "weekly"
+    cooldown:
+      default-days: 7
     groups:
       docs:
         update-types:
@@ -52,8 +58,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly" # when template is used, recommended interval is "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "monthly" # when template is used, recommended interval is "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,10 @@ jobs:
         with:
           enable-cache: true
 
+      - name: "Setup: install dependencies"
+        working-directory: ./api
+        run: uv sync --locked
+
       - name: "Run: pytest unit tests"
         working-directory: ./api
         run: uv run pytest --unit

--- a/.mise/tasks/generate.toml
+++ b/.mise/tasks/generate.toml
@@ -8,4 +8,4 @@ run = "uv run python -m app open-api"
 description = "Generate typescript types from the OpenAPI JSON Schema"
 depends = ["generate:openapi-spec"]
 dir = "{{config_root}}/web"
-run = "yarn install && yarn generate"
+run = "yarn install --immutable && yarn generate"

--- a/.mise/tasks/install-dependencies.toml
+++ b/.mise/tasks/install-dependencies.toml
@@ -1,9 +1,9 @@
 ["install-dependencies:api"]
 description = "Install the dependencies for the API"
 dir = "{{config_root}}/api"
-run = "uv sync"
+run = "uv sync --locked"
 
 ["install-dependencies:web"]
 description = "Install the dependencies for the Web application"
 dir = "{{config_root}}/web"
-run = "yarn install"
+run = "yarn install --immutable"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ USER "node"
 COPY --chown="node:node" .yarnrc.yml package.json yarn.lock ./
 ENV YARN_CACHE_FOLDER="/var/lib/yarn"
 RUN --mount=type=cache,target="$YARN_CACHE_FOLDER" \
-    yarn install
+    yarn install --immutable
 
 COPY --chown="node:node" index.html tsconfig.json vite.config.mts vitest.config.mts ./
 


### PR DESCRIPTION
## Summary

Hardens the project against supply-chain attacks on dependency updates.

### Dependabot cooldown

Adds a **7-day cooldown** to every configured ecosystem in `.github/dependabot.yml` (npm, docker, uv, github-actions, pre-commit). Dependabot will wait 7 days after a new version is published before proposing an update, reducing exposure to compromised/yanked releases.

### Enforce lockfile on all package installs

Every automated install path now refuses to silently update the lockfile:

| Location | Before | After |
|---|---|---|
| `web/Dockerfile` | `yarn install` | `yarn install --immutable` |
| `.mise/tasks/install-dependencies.toml` (api) | `uv sync` | `uv sync --locked` |
| `.mise/tasks/install-dependencies.toml` (web) | `yarn install` | `yarn install --immutable` |
| `.mise/tasks/generate.toml` | `yarn install && yarn generate` | `yarn install --immutable && yarn generate` |
| `.github/workflows/tests.yaml` (api-unit-tests) | `uv run pytest --unit` (implicit sync) | explicit `uv sync --locked` step added |

Already locked (unchanged): `api/Dockerfile`, `.mise/tasks/docs.toml`, `.github/workflows/publish-docs.yaml`, and the docs job in `tests.yaml`.

Human-facing setup/upgrade docs (`docs/docs/contribute/development-guide/01-setup.md`, `04-upgrading.md`) are intentionally left unlocked because upgrading requires lockfile changes.

### Notes

- Yarn 4 (Berry) uses `--immutable` as its equivalent of `--locked` / `--frozen-lockfile`.
- Dependabot `cooldown.default-days` is the documented option for delaying updates.