### PR TITLE
ci: pin GitHub Actions to full-length commit SHA

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -41,11 +41,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -56,6 +56,6 @@ jobs:
       # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy-to-radix.yaml
+++ b/.github/workflows/deploy-to-radix.yaml
@@ -35,13 +35,13 @@ jobs:
   deploy-on-radix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # You'll need an app registration with a Federated Credential for this to
       # work. Note that the credential will need to specify a branch name. This
       # step will therefore fail for all branches not mentioned in the credentials
       - name: Az CLI login
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: 4a761bec-628d-4c4b-860a-4903cbecc963 #app registration Application ID
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
@@ -56,7 +56,7 @@ jobs:
           echo "APP_SERVICE_ACCOUNT_TOKEN=$token" >> $GITHUB_ENV
 
       - name: Deploy on Radix
-        uses: equinor/radix-github-actions@v2
+        uses: equinor/radix-github-actions@b23674a56b82a1da783b507bc7f15e7ca7067dd8 # v2.0.2
         env:
           APP_SERVICE_ACCOUNT_TOKEN: ${{ env.APP_SERVICE_ACCOUNT_TOKEN }}
         with:

--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -21,14 +21,14 @@ jobs:
     name: "pre-commit"
     steps:
       - name: "Setup: checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Setup: Runtimes"
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         timeout-minutes: 5
 
       - name: "Run: pre-commit"
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: --all-files
 
@@ -40,14 +40,14 @@ jobs:
         working-directory: ./api
     steps:
       - name: "Setup: checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Setup: Runtimes"
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         timeout-minutes: 5
 
       - name: "Setup: install uv"
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -65,7 +65,7 @@ jobs:
         working-directory: ./web
     steps:
       - name: "Setup: check out repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github
@@ -73,13 +73,13 @@ jobs:
             web
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           path: /home/runner/.yarn/berry/cache
 
       - name: "Setup: Runtimes"
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         timeout-minutes: 5
 
       - name: "Run: compile"
@@ -90,7 +90,7 @@ jobs:
     name: "validate Radix config"
     steps:
       - name: "Setup: checkout repository"
-        uses: actions/checkout@v6
-      - uses: equinor/radix-github-actions@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: equinor/radix-github-actions@b23674a56b82a1da783b507bc7f15e7ca7067dd8 # v2.0.2
       - name: "Run: validate radix config"
         run: rx validate radix-config

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies and build website
         run: |

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -20,12 +20,12 @@ jobs:
   build-and-publish-nginx-main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: "Login to image registry"
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,12 +58,12 @@ jobs:
   build-and-publish-api-main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: "Login to image registry"
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -16,14 +16,14 @@ jobs:
     steps:
       - name: Create token
         id: create-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: release-please
         id: release-please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -25,7 +25,7 @@ jobs:
           ]
     steps:
       - name: "Login to image registry"
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Setup: checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Setup: install uv"
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -36,10 +36,10 @@ jobs:
   api-integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to image registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ false }} # disable for now as they do not currently work
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to image registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -85,12 +85,12 @@ jobs:
     steps:
       # If you know your docs does not rely on anything outside of the documentation folder, the commented out code below can be used to only test the docs build if the documentation folder changes.
       - name: Checkout GitHub Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # with:
         #   fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies and build website
         # if: steps.docs-changes.outputs.changes > 0


### PR DESCRIPTION
## Summary

Pins every third-party GitHub Actions reference in `.github/workflows/` to a full-length commit SHA, per the [Equinor AppSec guidance for GitHub Actions runners](https://equinor.github.io/appsec/toolbox/version-control/gh-actions-runners/#github-actions-in-general).

Tag references like `actions/checkout@v6` are mutable and can be repointed by the action's maintainer (or an attacker who compromises their account) to malicious code that then runs with our workflow's secrets. Pinning to a commit SHA makes the reference immutable.

## What changed

Every `uses:` line that references a third-party action now uses a 40-character commit SHA with a trailing `# vX.Y.Z` comment:

```yaml
- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

The trailing version comment is preserved so Dependabot's GitHub Actions updater can bump the SHA and the human-readable version label together when a new release ships.

## How the SHAs were chosen

Each SHA was resolved by querying `api.github.com/repos/<owner>/<repo>/commits/<tag>` for the major-version tag currently used in this repo (e.g. `v6` -> `v6.0.2` -> `de0fac2…`), so every pin is the exact commit that the previously-floating tag pointed to at the time of this PR.

## Actions pinned

| Action | Pinned version |
|---|---|
| `actions/cache` | v5.0.5 |
| `actions/checkout` | v6.0.2 |
| `actions/create-github-app-token` | v3.2.0 |
| `astral-sh/setup-uv` | v7.6.0 |
| `azure/login` | v3.0.0 |
| `docker/login-action` | v4.1.0 |
| `equinor/radix-github-actions` | v2.0.2 |
| `github/codeql-action` (init + analyze) | v4.35.5 |
| `googleapis/release-please-action` | v5.0.0 |
| `jdx/mise-action` | v4.0.1 |
| `pre-commit/action` | v3.0.1 |