### PR TITLE
fix(ci): remove non-existent web image from rollback matrix

### DIFF
--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -20,7 +20,6 @@ jobs:
         image:
           [
             ghcr.io/equinor/template-fastapi-react/api,
-            ghcr.io/equinor/template-fastapi-react/web,
             ghcr.io/equinor/template-fastapi-react/nginx,
           ]
     steps:


### PR DESCRIPTION
The `publish-image` workflow no longer builds a standalone `web` image — the frontend is bundled into the `nginx` image. Attempting a rollback would therefore fail with a `manifest unknown` error on the `web` matrix entry.

This PR removes `ghcr.io/equinor/template-fastapi-react/web` from the rollback matrix so only the images that are actually published (`api`, `nginx`) are tagged.