### PR TITLE
chore(ci): declare least-privilege permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -9,6 +9,9 @@ on:
         description: "Secret to authenticate if using an other container registry than Github"
         required: false
 
+permissions:
+  contents: read
+
 env:
   IMAGE_REGISTRY: ghcr.io
   REGISTRY_USER: $GITHUB_ACTOR

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   linting-and-checks:
     name: "Linting and checks"
@@ -10,4 +13,7 @@ jobs:
 
   tests:
     name: "Tests"
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   linting-and-checks:
     name: "Linting and checks"
@@ -12,16 +15,24 @@ jobs:
 
   tests:
     name: "Tests"
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/tests.yaml
 
   docs:
     needs: tests
     name: "Build and publish docs"
+    permissions:
+      contents: write
     uses: ./.github/workflows/publish-docs.yaml
 
   publish-latest:
     needs: tests
     name: "Publish dev docker images"
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/publish-image.yaml
     with:
       image-tags: latest
@@ -46,6 +57,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     name: "Publish staging docker images"
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/publish-image.yaml
     with:
       image-tags: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: write
+
 env:
   GITHUB_PAGES_BRANCH: gh-pages
 

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -12,6 +12,10 @@ on:
         description: "Secret to authenticate if using an other container registry than Github"
         required: false
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   API_IMAGE: ghcr.io/equinor/template-fastapi-react/api
   NGINX_IMAGE: ghcr.io/equinor/template-fastapi-react/nginx

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,6 +10,9 @@ on:
         description: "The released tag. Ex 'v1.2.3'"
         value: ${{ jobs.release-please.outputs.tag_name }}
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,10 @@ on:
         description: "Secret to authenticate if using an other container registry than Github"
         required: false
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   API_IMAGE: ghcr.io/equinor/template-fastapi-react/api
   WEB_IMAGE: ghcr.io/equinor/template-fastapi-react/web


### PR DESCRIPTION
Explicitly set `permissions:` on every workflow rather than relying on the repository default `GITHUB_TOKEN` scopes. Each workflow now requests only what it actually needs.

| Workflow | Scopes granted |
| --- | --- |
| `publish-image` | `contents: read`, `packages: write` (push to ghcr.io) |
| `publish-docs` | `contents: write` (force-push to `gh-pages`) |
| `tests` | `contents: read`, `packages: read` (pull ghcr images) |
| `linting-and-checks` | `contents: read` |
| `release-please` | `contents: read` (uses a GitHub App token for writes) |
| `on-pull-request` / `on-push-main-branch` | `contents: read` at workflow level, with per-job elevation where reusable workflows need more than the caller |

`deploy-to-radix` and `rollback` already declared explicit permissions and are unchanged.

### Why per-job permissions on the callers?
GitHub will not let a called reusable workflow exceed the caller job's permissions, so the publish/docs/tests jobs in `on-push-main-branch.yaml` (and the tests job in `on-pull-request.yaml`) explicitly elevate their `packages` / `contents` scopes.