### PR TITLE
chore(ci): cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   linting-and-checks:
     name: "Linting and checks"


### PR DESCRIPTION
Adds a `concurrency` group keyed by PR number to the `on-pull-request` workflow:

```yaml
concurrency:
  group: pr-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

When new commits are pushed to a PR, any still-running checks from earlier commits are cancelled. This saves runner minutes and gives quicker feedback on the latest commit.

Only applied to the PR workflow for now — pushes to `main` are intentionally left to run to completion to avoid interrupting releases/deploys.