### PR TITLE
ci: deploy docs via official GitHub Pages actions

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,24 +4,24 @@ on:
   workflow_dispatch:
   workflow_call:
 
-# actions/deploy-pages uses OIDC (id-token: write) and the Pages REST API
-# (pages: write); contents: read is enough for the checkout in the build job.
 permissions:
   contents: read
   pages: write
-  id-token: write
+  id-token: write # actions/deploy-pages uses OIDC
 
-# Pages deployments must not run in parallel. Do not cancel an in-flight
-# deployment, otherwise we risk leaving the site in a broken state.
+# Force previous deployment to complete before starting a new one
+# to prevent deployments overwriting each other
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: "Build docs site"
+  publish-docs:
+    name: "Publish docs site"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,15 +45,6 @@ jobs:
         with:
           path: ./docs/site
 
-  deploy:
-    name: "Deploy to GitHub Pages"
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,38 +4,56 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# actions/deploy-pages uses OIDC (id-token: write) and the Pages REST API
+# (pages: write); contents: read is enough for the checkout in the build job.
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
-env:
-  GITHUB_PAGES_BRANCH: gh-pages
+# Pages deployments must not run in parallel. Do not cancel an in-flight
+# deployment, otherwise we risk leaving the site in a broken state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  publish-docs:
+  build:
+    name: "Build docs site"
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
 
       - name: Install dependencies and build website
+        working-directory: ./docs
         run: |
-          cd docs
           uv sync --locked
           uv run zensical build
 
-      - name: Push static files to Github Pages branch
-        run: |
-          cd docs/site
-          CREATED_FROM_REF=$(git rev-parse --short HEAD)
-          git init
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          git checkout -b $GITHUB_PAGES_BRANCH
-          git remote add $GITHUB_PAGES_BRANCH https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/equinor/template-fastapi-react
-          git add .
-          git commit -m "Built from commit '$CREATED_FROM_REF'"
-          git push -f --set-upstream gh-pages gh-pages
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./docs/site
+
+  deploy:
+    name: "Deploy to GitHub Pages"
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Replace the hand-rolled `git init` + force-push-to-`gh-pages` approach in [`publish-docs.yaml`](.github/workflows/publish-docs.yaml) with the officially supported [`actions/configure-pages`](https://github.com/actions/configure-pages), [`actions/upload-pages-artifact`](https://github.com/actions/upload-pages-artifact) and [`actions/deploy-pages`](https://github.com/actions/deploy-pages).

### Why
- OIDC-based deploy: no `contents: write` scope on `GITHUB_TOKEN` is needed for docs anymore.
- No force-pushed `gh-pages` branch to maintain.
- Uses the GitHub-managed `github-pages` environment, which gives you protection rules, a clean deploy history, and surfaces the deployment URL in the Actions run UI via `environment.url` (note: this is *not* exposed as a programmatic workflow output — nothing currently consumes it, so a `workflow_call` output isn't worth adding).

### Other small cleanups in the same file (items 15 + a couple of bonus fixes)
- Explicit `permissions:` block: `contents: read`, `pages: write`, `id-token: write` — required by `actions/deploy-pages`.
- `setup-uv` now uses `enable-cache: true`, matching the other workflows.
- Added a `pages` concurrency group with `cancel-in-progress: false` so Pages deploys are serialised but never interrupted mid-deploy.
- Added `timeout-minutes` safety nets on both jobs.
- Dropped the now-unused `GITHUB_PAGES_BRANCH` env var.

### ⚠️ One-time manual step required before merging
The repository's Pages source must be switched to "GitHub Actions":
**Settings → Pages → Build and deployment → Source → GitHub Actions**.

While the source is still set to "Deploy from a branch", `actions/deploy-pages` will fail. Once switched, the existing `gh-pages` branch can be deleted (optional cleanup).

### Interaction with other open PRs
- **#557** (least-privilege permissions) adds `permissions: contents: write` to the `docs` job in `on-push-main-branch.yaml`. After both PRs land, that needs to become `pages: write, id-token: write, contents: read` instead. Whichever PR merges second will need a trivial rebase — I'll do that follow-up.