### PR TITLE
chore(ci): read Azure client/tenant IDs from repo variables

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -41,9 +41,9 @@ jobs:
           printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./web/public/version.txt
           docker build \
           --build-arg AUTH_ENABLED=1 \
-          --build-arg AUTH_SCOPE=api://4a761bec-628d-4c4b-860a-4903cbecc963/api \
-          --build-arg CLIENT_ID=4a761bec-628d-4c4b-860a-4903cbecc963 \
-          --build-arg TENANT_ID=3aa4a235-b6e2-48d5-9195-7fcf05b459b0 \
+          --build-arg AUTH_SCOPE=api://${{ vars.AZURE_CLIENT_ID }}/api \
+          --build-arg CLIENT_ID=${{ vars.AZURE_CLIENT_ID }} \
+          --build-arg TENANT_ID=${{ vars.AZURE_TENANT_ID }} \
           --cache-from ${NGINX_IMAGE} \
           --tag ${NGINX_IMAGE} \
           --target nginx-prod \


### PR DESCRIPTION
Move the Azure app registration values used as Docker build args in [`publish-image.yaml`](.github/workflows/publish-image.yaml) out of the YAML and read them from repository variables instead.

`AUTH_SCOPE` is derived from `AZURE_CLIENT_ID` (`api://<client-id>/api`) so only two new variables are required.

| Build arg | Previous value | Now reads |
| --- | --- | --- |
| `AUTH_SCOPE` | `api://4a761bec-…/api` | `api://${{ vars.AZURE_CLIENT_ID }}/api` |
| `CLIENT_ID` | `4a761bec-…` | `${{ vars.AZURE_CLIENT_ID }}` |
| `TENANT_ID` | `3aa4a235-…` | `${{ vars.AZURE_TENANT_ID }}` |

### Why
Downstream forks of this template can now point at their own Azure app registration purely through *Settings → Variables*, without editing the workflow file.

### Variables — already set
Both variables are already configured on this repo with the original values, so behaviour is unchanged after merge:

```
AZURE_CLIENT_ID = 4a761bec-628d-4c4b-860a-4903cbecc963
AZURE_TENANT_ID = 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
```

### Scope
- `deploy-to-radix.yaml` also embeds the same IDs plus the Radix app name/user, but it's currently not invoked by any workflow — left out of this PR to keep the change focused. Happy to do that as a separate PR if/when those deploy jobs are re-enabled.