### PR TITLE
chore(ci): align test jobs with mise tasks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,18 +4,10 @@ on:
   workflow_dispatch:
   # Workflow call is used for called from another workflow
   workflow_call:
-    secrets:
-      CR_SECRET:
-        description: "Secret to authenticate if using an other container registry than Github"
-        required: false
 
 permissions:
   contents: read
   packages: read
-
-env:
-  API_IMAGE: ghcr.io/equinor/template-fastapi-react/api
-  WEB_IMAGE: ghcr.io/equinor/template-fastapi-react/web
 
 jobs:
   api-unit-tests:
@@ -24,21 +16,22 @@ jobs:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: "Setup: Runtimes"
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        timeout-minutes: 5
+
       - name: "Setup: install uv"
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
-      - name: "Setup: install dependencies"
-        working-directory: ./api
-        run: uv sync --locked
-
       - name: "Run: pytest unit tests"
-        working-directory: ./api
-        run: uv run pytest --unit
+        run: mise run test:api:unit
 
   api-integration-tests:
     runs-on: ubuntu-latest
+    env:
+      API_IMAGE: ghcr.io/equinor/template-fastapi-react/api
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -63,6 +56,8 @@ jobs:
   web-tests:
     runs-on: ubuntu-latest
     if: ${{ false }} # disable for now as they do not currently work
+    env:
+      NGINX_IMAGE: ghcr.io/equinor/template-fastapi-react/nginx
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -75,8 +70,8 @@ jobs:
 
       - name: Build Web Image
         run: |
-          docker pull $WEB_IMAGE
-          docker build --cache-from $WEB_IMAGE --target development --tag web-dev ./web
+          docker pull $NGINX_IMAGE
+          docker build --cache-from $NGINX_IMAGE --target development --tag web-dev ./web
 
       - name: Run Web tests
         if: ${{ false }} # disable for now as they do not currently work
@@ -87,18 +82,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # If you know your docs does not rely on anything outside of the documentation folder, the commented out code below can be used to only test the docs build if the documentation folder changes.
-      - name: Checkout GitHub Action
+      - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        # with:
-        #   fetch-depth: 0
 
-      - name: Install uv
+      - name: "Setup: Runtimes"
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        timeout-minutes: 5
+
+      - name: "Setup: install uv"
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
 
-      - name: Install dependencies and build website
-        # if: steps.docs-changes.outputs.changes > 0
-        run: |
-          cd docs
-          uv sync --locked
-          uv run zensical build
+      - name: "Run: build docs site"
+        run: mise run docs:build

--- a/.mise/tasks/test.toml
+++ b/.mise/tasks/test.toml
@@ -1,0 +1,5 @@
+["test:api:unit"]
+description = "Run the API unit tests"
+depends = ["install-dependencies:api"]
+dir = "{{config_root}}/api"
+run = "uv run pytest --unit"


### PR DESCRIPTION
Make the test jobs use the same mise-action + setup-uv + `mise run <task>` pattern already established by the `mypy` and `typescript-compile` jobs in `linting-and-checks.yaml`, so local `mise run <task>` and CI behave identically.

## Changes

- Add `.mise/tasks/test.toml` with a `test:api:unit` task (`cd api && uv run pytest --unit`, depends on `install-dependencies:api`).
- Rewrite `api-unit-tests` to use `mise-action` + `setup-uv` + `mise run test:api:unit`.
- Rewrite `docs-tests` to use `mise-action` + `setup-uv` + `mise run docs:build` (existing task). Renamed the misleading "Checkout GitHub Action" step name and dropped the commented-out `fetch-depth`/`if` lines.
- Drop unused `CR_SECRET` `workflow_call` input — it was declared but never referenced in the file, and no caller passes it.
- Move `API_IMAGE` env into the `api-integration-tests` job (its only consumer).
- Rename dead `WEB_IMAGE` to `NGINX_IMAGE` in the (currently disabled) `web-tests` job, matching the image actually published by `publish-image.yaml` (`ghcr.io/equinor/template-fastapi-react/nginx`). Scoped to that job.

## Notes / out of scope

- Considered also dropping the `mypy` / `typescript-compile` jobs as redundant with pre-commit, but `.pre-commit-config.yaml` does not include `mypy` or `tsc` — so those jobs are *not* redundant. Dismissed.
- Considered converting the raw `docker pull` + `docker build` steps in `api-integration-tests` / `web-tests` to `docker/build-push-action`. Deferred to a follow-up PR that will also cover `publish-image.yaml`.
- `web-tests` remains `if: \${{ false }}` (separate cleanup item).