### PR TITLE
chore(ci): build images with docker/build-push-action

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -35,29 +35,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Build web"
-        run: |
-          docker pull $NGINX_IMAGE
-          printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./web/public/version.txt
-          docker build \
-          --build-arg AUTH_ENABLED=1 \
-          --build-arg AUTH_SCOPE=api://${{ vars.AZURE_CLIENT_ID }}/api \
-          --build-arg CLIENT_ID=${{ vars.AZURE_CLIENT_ID }} \
-          --build-arg TENANT_ID=${{ vars.AZURE_TENANT_ID }} \
-          --cache-from ${NGINX_IMAGE} \
-          --tag ${NGINX_IMAGE} \
-          --target nginx-prod \
-          ./web
+      - name: "Setup: Buildx"
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: "Publish web"
+      - name: "Prepare: version.txt and tags"
+        id: prep
         run: |
-          IFS=','
-          for IMAGE_TAG in $(echo ${{ inputs.image-tags }})
-          do
-            echo "Tagging with $IMAGE_TAG"
-            docker tag $NGINX_IMAGE $NGINX_IMAGE:$IMAGE_TAG
-            docker push $NGINX_IMAGE:$IMAGE_TAG
-          done
+          printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./web/public/version.txt
+          {
+            echo "tags<<EOF"
+            IFS=','
+            for t in ${{ inputs.image-tags }}; do
+              echo "${NGINX_IMAGE}:${t}"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: "Build & publish web"
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./web
+          target: nginx-prod
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.NGINX_IMAGE }}:latest
+          cache-to: type=inline
+          build-args: |
+            AUTH_ENABLED=1
+            AUTH_SCOPE=api://${{ vars.AZURE_CLIENT_ID }}/api
+            CLIENT_ID=${{ vars.AZURE_CLIENT_ID }}
+            TENANT_ID=${{ vars.AZURE_TENANT_ID }}
 
   build-and-publish-api-main:
     runs-on: ubuntu-latest
@@ -73,18 +80,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Build API"
-        run: |
-          docker pull $API_IMAGE
-          printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./api/src/version.txt
-          docker build --cache-from $API_IMAGE --target prod --tag $API_IMAGE ./api
+      - name: "Setup: Buildx"
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: "Publish API"
+      - name: "Prepare: version.txt and tags"
+        id: prep
         run: |
-          IFS=','
-          for IMAGE_TAG in $(echo ${{ inputs.image-tags }})
-          do
-            echo "Tagging with $IMAGE_TAG"
-            docker tag $API_IMAGE $API_IMAGE:$IMAGE_TAG
-            docker push $API_IMAGE:$IMAGE_TAG
-          done
+          printf "$(git log -n 1 --format=format:'hash: %h%ndate: %cs%nrefs: %d' --decorate=short --decorate-refs=refs/tags | sed 's/ (tag: \([^\s]*\))/\1/')" > ./api/src/version.txt
+          {
+            echo "tags<<EOF"
+            IFS=','
+            for t in ${{ inputs.image-tags }}; do
+              echo "${API_IMAGE}:${t}"
+            done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: "Build & publish API"
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./api
+          target: prod
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.API_IMAGE }}:latest
+          cache-to: type=inline

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,10 +42,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Setup: Buildx"
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build API image
-        run: |
-          docker pull $API_IMAGE
-          docker build --target development --tag api-development ./api # TODO: --cache-from $API_IMAGE
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./api
+          target: development
+          tags: api-development:latest
+          load: true
+          push: false
+          cache-from: type=registry,ref=${{ env.API_IMAGE }}:latest
+
       - name: BDD Integration tests
         if: ${{ false }} # disable for now
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml run api behave
@@ -68,10 +77,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Setup: Buildx"
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build Web Image
-        run: |
-          docker pull $NGINX_IMAGE
-          docker build --cache-from $NGINX_IMAGE --target development --tag web-dev ./web
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./web
+          target: development
+          tags: web-dev:latest
+          load: true
+          push: false
+          cache-from: type=registry,ref=${{ env.NGINX_IMAGE }}:latest
 
       - name: Run Web tests
         if: ${{ false }} # disable for now as they do not currently work


### PR DESCRIPTION
Replace raw `docker pull` + `docker build` + (where applicable) tag/push loops with the canonical `docker/setup-buildx-action` + `docker/build-push-action` pair. Follow-up to #563.

## `publish-image.yaml`

- `nginx` and `api` build jobs now use `build-push-action` with:
  - multi-tag `tags` list computed from the comma-separated `image-tags` input,
  - `cache-from: type=registry,ref=<image>:latest`,
  - `cache-to: type=inline` so subsequent builds keep getting registry cache hits without an explicit pre-pull step.
- `target`, `context`, `build-args` are now declarative.
- The hand-rolled "tag in a loop, then push" `Publish` steps are gone — `build-push-action` pushes all tags directly.

## `tests.yaml`

- `api-integration-tests` and (disabled) `web-tests` build steps use `build-push-action` with `load: true, push: false`, so the image is available to the daemon for the subsequent `docker compose run` step.

## Notes

- No behavior change to the published tag set or registry. The `docker compose` test invocations are unchanged.
- Stacked on top of #563 — please merge that first; PR base is set to its branch.