### PR TITLE
ci(on-push-main): grant pages/id-token perms to docs job

### DIFF
--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -24,7 +24,9 @@ jobs:
     needs: tests
     name: "Build and publish docs"
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/publish-docs.yaml
 
   publish-latest:


### PR DESCRIPTION
Follow-up to #559.

The reusable [`publish-docs.yaml`](.github/workflows/publish-docs.yaml) workflow now uses `actions/deploy-pages` (OIDC) instead of pushing to `gh-pages`, so it requires:

- `contents: read`
- `pages: write`
- `id-token: write`

The caller in [`on-push-main-branch.yaml`](.github/workflows/on-push-main-branch.yaml) was still granting only `contents: write`, which caused the post-merge run to fail:

> The workflow is requesting `pages: write, id-token: write`, but is only allowed `pages: none, id-token: none`.

This PR updates the `docs` job's `permissions:` block to match what the reusable workflow needs.