### PR TITLE
chore: remove .md file extension from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Equinor
+Copyright (c) Equinor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Why is this pull request needed?

Just see that its common to _not_ have the license as a markdown file, but instead have it as a pure text file 
(see for instance https://github.com/facebook/react/blob/main/LICENSE). 

This only really impacts how its shown when viewing the file through GitHub

## What does this pull request change?

Removes `.md` from the LICENSE