### PR TITLE
ci: create reusable setup-environment github action

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -1,11 +1,18 @@
 name: Set up environment
 description: Configure development environment with all runtimes and dependencies
 
+inputs:
+  sparse-setup:
+    description: 'Comma separated list of components to set up. Defaults to "api, web, docs".'
+    required: false
+    default: "api, web, docs"
+
 runs:
   using: composite
   steps:
     - name: "Cache: API dependencies"
       id: cache-api
+      if: contains(inputs.sparse-setup, 'api')
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: api/.venv
@@ -13,6 +20,7 @@ runs:
 
     - name: "Cache: web dependencies"
       id: cache-web
+      if: contains(inputs.sparse-setup, 'web')
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: /home/runner/.yarn/berry/cache
@@ -20,6 +28,7 @@ runs:
 
     - name: "Cache: docs dependencies"
       id: cache-docs
+      if: contains(inputs.sparse-setup, 'docs')
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: docs/.venv
@@ -29,14 +38,17 @@ runs:
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
     - name: "Setup: install API dependencies"
+      if: contains(inputs.sparse-setup, 'api')
       shell: bash
       run: mise run install-dependencies:api
 
     - name: "Setup: web dependencies"
+      if: contains(inputs.sparse-setup, 'web')
       shell: bash
       run: mise run install-dependencies:web
 
     - name: "Setup: install docs dependencies"
+      if: contains(inputs.sparse-setup, 'docs')
       working-directory: ./docs
       shell: bash
       run: uv sync --locked

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -1,0 +1,42 @@
+name: Set up environment
+description: Configure development environment with all runtimes and dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: "Cache: API dependencies"
+      id: cache-api
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: api/.venv
+        key: deps-api-${{ runner.os }}-${{ hashFiles('.mise/config.toml', 'api/pyproject.toml', 'api/uv.lock') }}
+
+    - name: "Cache: web dependencies"
+      id: cache-web
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: /home/runner/.yarn/berry/cache
+        key: deps-web-${{ runner.os }}-${{ hashFiles('.mise/config.toml', 'web/yarn.lock') }}
+
+    - name: "Cache: docs dependencies"
+      id: cache-docs
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: docs/.venv
+        key: deps-docs-${{ runner.os }}-${{ hashFiles('.mise/config.toml', 'docs/pyproject.toml', 'docs/uv.lock') }}
+
+    - name: "Setup: Runtimes"
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+    - name: "Setup: install API dependencies"
+      shell: bash
+      run: mise run install-dependencies:api
+
+    - name: "Setup: web dependencies"
+      shell: bash
+      run: mise run install-dependencies:web
+
+    - name: "Setup: install docs dependencies"
+      working-directory: ./docs
+      shell: bash
+      run: uv sync --locked

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -1,18 +1,12 @@
 name: Set up environment
 description: Configure development environment with all runtimes and dependencies
 
-inputs:
-  sparse-setup:
-    description: 'Comma separated list of components to set up. Defaults to "api, web, docs".'
-    required: false
-    default: "api, web, docs"
-
 runs:
   using: composite
   steps:
     - name: "Cache: API dependencies"
       id: cache-api
-      if: contains(inputs.sparse-setup, 'api')
+      if: hashFiles('api') != ''
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: api/.venv
@@ -20,7 +14,7 @@ runs:
 
     - name: "Cache: web dependencies"
       id: cache-web
-      if: contains(inputs.sparse-setup, 'web')
+      if: hashFiles('web') != ''
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: /home/runner/.yarn/berry/cache
@@ -28,7 +22,7 @@ runs:
 
     - name: "Cache: docs dependencies"
       id: cache-docs
-      if: contains(inputs.sparse-setup, 'docs')
+      if: hashFiles('docs') != ''
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: docs/.venv
@@ -38,17 +32,17 @@ runs:
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
     - name: "Setup: install API dependencies"
-      if: contains(inputs.sparse-setup, 'api')
+      if: hashFiles('api') != ''
       shell: bash
       run: mise run install-dependencies:api
 
     - name: "Setup: web dependencies"
-      if: contains(inputs.sparse-setup, 'web')
+      if: hashFiles('web') != ''
       shell: bash
       run: mise run install-dependencies:web
 
     - name: "Setup: install docs dependencies"
-      if: contains(inputs.sparse-setup, 'docs')
+      if: hashFiles('docs') != ''
       working-directory: ./docs
       shell: bash
       run: uv sync --locked

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ registries:
 
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/.github/workflows"
+      - "/.github/actions/*"
     groups:
       actions:
         update-types:

--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -44,9 +44,16 @@ jobs:
     steps:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github
+            .mise
+            api
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
+        with:
+          sparse-setup: api
         timeout-minutes: 5
 
       - name: "Run: mypy"
@@ -61,9 +68,16 @@ jobs:
     steps:
       - name: "Setup: check out repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github
+            .mise
+            web
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
+        with:
+          sparse-setup: web
         timeout-minutes: 5
 
       - name: "Run: compile"

--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -52,8 +52,6 @@ jobs:
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
-        with:
-          sparse-setup: api
         timeout-minutes: 5
 
       - name: "Run: mypy"
@@ -76,8 +74,6 @@ jobs:
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
-        with:
-          sparse-setup: web
         timeout-minutes: 5
 
       - name: "Run: compile"

--- a/.github/workflows/linting-and-checks.yaml
+++ b/.github/workflows/linting-and-checks.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: "Setup: Runtimes"
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: "Setup: Environment"
+        uses: ./.github/actions/setup-environment
         timeout-minutes: 5
 
       - name: "Run: pre-commit"
@@ -45,17 +45,9 @@ jobs:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: "Setup: Runtimes"
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: "Setup: Environment"
+        uses: ./.github/actions/setup-environment
         timeout-minutes: 5
-
-      - name: "Setup: install uv"
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-
-      - name: "Setup: install dependencies"
-        run: mise run install-dependencies:api
 
       - name: "Run: mypy"
         run: mise run lint:api:typecheck
@@ -69,20 +61,9 @@ jobs:
     steps:
       - name: "Setup: check out repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: |
-            .github
-            .mise
-            web
 
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          path: /home/runner/.yarn/berry/cache
-
-      - name: "Setup: Runtimes"
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: "Setup: Environment"
+        uses: ./.github/actions/setup-environment
         timeout-minutes: 5
 
       - name: "Run: compile"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -25,9 +25,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github
+            .mise
+            docs
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
+        with:
+          sparse-setup: docs
         timeout-minutes: 5
 
       - name: Build website

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -26,16 +26,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
+      - name: "Setup: Environment"
+        uses: ./.github/actions/setup-environment
+        timeout-minutes: 5
 
-      - name: Install dependencies and build website
+      - name: Build website
         working-directory: ./docs
-        run: |
-          uv sync --locked
-          uv run zensical build
+        run: uv run zensical build
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -33,8 +33,6 @@ jobs:
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
-        with:
-          sparse-setup: docs
         timeout-minutes: 5
 
       - name: Build website

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,14 +16,9 @@ jobs:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: "Setup: Runtimes"
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: "Setup: Environment"
+        uses: ./.github/actions/setup-environment
         timeout-minutes: 5
-
-      - name: "Setup: install uv"
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
 
       - name: "Run: pytest unit tests"
         run: mise run test:api:unit
@@ -85,14 +80,9 @@ jobs:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: "Setup: Runtimes"
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: "Setup: Environment"
+        uses: ./.github/actions/setup-environment
         timeout-minutes: 5
-
-      - name: "Setup: install uv"
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
 
       - name: "Run: build docs site"
         run: mise run docs:build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,9 +15,16 @@ jobs:
     steps:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github
+            .mise
+            api
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
+        with:
+          sparse-setup: api
         timeout-minutes: 5
 
       - name: "Run: pytest unit tests"
@@ -79,9 +86,16 @@ jobs:
     steps:
       - name: "Setup: checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github
+            .mise
+            docs
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
+        with:
+          sparse-setup: docs
         timeout-minutes: 5
 
       - name: "Run: build docs site"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,8 +23,6 @@ jobs:
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
-        with:
-          sparse-setup: api
         timeout-minutes: 5
 
       - name: "Run: pytest unit tests"
@@ -94,8 +92,6 @@ jobs:
 
       - name: "Setup: Environment"
         uses: ./.github/actions/setup-environment
-        with:
-          sparse-setup: docs
         timeout-minutes: 5
 
       - name: "Run: build docs site"


### PR DESCRIPTION
## Why is this pull request needed?

Instead of manually handling runtimes, dependencies and caching, per individual workflow, we can have a single re-usable composite action to handle all of this the same way everywhere

## What does this pull request change?

Crates a local GitHub action whose role is to install all the runtimes and dependencies required for all the components. This action should allow easy setup that matches a full local development setup.

### Considerations

Kept the action simple, so it _always_ installs _all_ the different components (api/web/docs) even though it might be redundant for some workflows. An option is to add an input so one could choose which component to install.